### PR TITLE
chore(whatsapp-stay): bump whatsapp-api-js v5 → v6.2.2-beta.0 (FOU-327)

### DIFF
--- a/integrations/whatsapp/integration.definition.ts
+++ b/integrations/whatsapp/integration.definition.ts
@@ -157,7 +157,7 @@ const defaultBotPhoneNumberId = {
 }
 
 export const INTEGRATION_NAME = 'whatsapp-stay'
-export const INTEGRATION_VERSION = '1.1.0'
+export const INTEGRATION_VERSION = '1.2.0'
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
   version: INTEGRATION_VERSION,

--- a/integrations/whatsapp/package.json
+++ b/integrations/whatsapp/package.json
@@ -18,7 +18,7 @@
     "marked": "^15.0.1",
     "preact": "^10.26.6",
     "preact-render-to-string": "^6.5.13",
-    "whatsapp-api-js": "^5.3.0"
+    "whatsapp-api-js": "6.2.2-beta.0"
   },
   "devDependencies": {
     "@botpress/cli": "workspace:*",

--- a/integrations/whatsapp/src/actions/start-conversation.ts
+++ b/integrations/whatsapp/src/actions/start-conversation.ts
@@ -112,7 +112,7 @@ export const startConversation: bp.IntegrationProps['actions']['startConversatio
   const language = new Language(templateLanguage)
   const template = new Template(templateName, language, ...templateApiComponents)
 
-  const response = await whatsapp.sendMessage(botPhoneNumberId, userPhone, template)
+  const response = await whatsapp.sendMessage(botPhoneNumberId, { phone: userPhone }, template)
 
   if ('error' in response) {
     const errorJSON = JSON.stringify(response.error)

--- a/integrations/whatsapp/src/actions/start-flow.ts
+++ b/integrations/whatsapp/src/actions/start-flow.ts
@@ -97,7 +97,7 @@ export const startFlow = async ({ ctx, input, client, logger }: any) => {
 
   const interactive = new Interactive(new ActionFlow(parameters), new Body(bodyText))
 
-  const response = await whatsapp.sendMessage(botPhoneNumberId, userPhone, interactive)
+  const response = await whatsapp.sendMessage(botPhoneNumberId, { phone: userPhone }, interactive)
 
   if ('error' in response) {
     const errorJSON = JSON.stringify(response.error)

--- a/integrations/whatsapp/src/actions/typing-indicator.ts
+++ b/integrations/whatsapp/src/actions/typing-indicator.ts
@@ -24,7 +24,7 @@ export const startTypingIndicator: bp.IntegrationProps['actions']['startTypingIn
   })
   if (ctx.configuration.typingIndicatorEmoji) {
     void whatsapp
-      .sendMessage(botPhoneNumberId, userPhone, new Reaction(whatsappMessageId, '👀'))
+      .sendMessage(botPhoneNumberId, { phone: userPhone }, new Reaction(whatsappMessageId, '👀'))
       .catch((e) => logger.forBot().error(`Error sending typing indicator emoji: ${e ?? '[Unknown error]'}`))
   }
   return {}
@@ -42,7 +42,7 @@ export const stopTypingIndicator: bp.IntegrationProps['actions']['stopTypingIndi
   const { conversationId, messageId } = input
   const { botPhoneNumberId, userPhone } = await _getConversationInfos(client, conversationId)
   const { whatsappMessageId } = await _getMessageInfos(client, messageId)
-  await whatsapp.sendMessage(botPhoneNumberId, userPhone, new Reaction(whatsappMessageId))
+  await whatsapp.sendMessage(botPhoneNumberId, { phone: userPhone }, new Reaction(whatsappMessageId))
   return {}
 }
 

--- a/integrations/whatsapp/src/channels/channel.ts
+++ b/integrations/whatsapp/src/channels/channel.ts
@@ -290,7 +290,7 @@ async function _send({ client, ctx, conversation, logger, message, ack }: SendMe
         logger.forBot().info(`Retrying to send ${messageType} message to WhatsApp (attempt ${i + 1}/${MAX_ATTEMPT})...`)
       }
 
-      const result = await whatsapp.sendMessage(botPhoneNumberId, userPhoneNumber, message)
+      const result = await whatsapp.sendMessage(botPhoneNumberId, { phone: userPhoneNumber }, message)
       const repeat = 'error' in result && THROTTLING_CODES.has(result.error?.code ?? 0)
       return {
         repeat,

--- a/integrations/whatsapp/src/webhook/handlers/sandbox.ts
+++ b/integrations/whatsapp/src/webhook/handlers/sandbox.ts
@@ -43,7 +43,7 @@ const _handleJoinCommand = async (props: bp.HandlerProps) => {
   const whatsapp = await getAuthenticatedWhatsappClient(client, ctx)
 
   await whatsapp.markAsRead(botPhoneNumberId, message.id, 'text')
-  await whatsapp.sendMessage(botPhoneNumberId, userPhoneNumber, new Text(CONVERSATION_CONNECTED_MESSAGE))
+  await whatsapp.sendMessage(botPhoneNumberId, { phone: userPhoneNumber }, new Text(CONVERSATION_CONNECTED_MESSAGE))
   return
 }
 
@@ -60,7 +60,7 @@ const _handleLeaveCommand = async (props: bp.HandlerProps) => {
   const whatsapp = await getAuthenticatedWhatsappClient(client, ctx)
 
   await whatsapp.markAsRead(botPhoneNumberId, message.id, 'text')
-  await whatsapp.sendMessage(botPhoneNumberId, userPhoneNumber, new Text(CONVERSATION_DISCONNECTED_MESSAGE))
+  await whatsapp.sendMessage(botPhoneNumberId, { phone: userPhoneNumber }, new Text(CONVERSATION_DISCONNECTED_MESSAGE))
   return
 }
 

--- a/integrations/whatsapp/src/webhook/handlers/status.ts
+++ b/integrations/whatsapp/src/webhook/handlers/status.ts
@@ -119,7 +119,7 @@ export const statusHandler = async (value: WhatsAppStatusValue, props: bp.Handle
                 `WhatsApp rejected the ${message.type} (code ${mediaErrorCode}); sending the URL as a plain text fallback to ${userPhone}.`
               )
             const whatsapp = await getAuthenticatedWhatsappClient(client, ctx)
-            await whatsapp.sendMessage(botPhoneNumberId, userPhone, new Text(mediaUrl))
+            await whatsapp.sendMessage(botPhoneNumberId, { phone: userPhone }, new Text(mediaUrl))
           }
         } catch (err) {
           logger.forBot().error('Failed to send the plain text URL fallback for the rejected media:', err)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2253,8 +2253,8 @@ importers:
         specifier: ^6.5.13
         version: 6.5.13(preact@10.26.6)
       whatsapp-api-js:
-        specifier: ^5.3.0
-        version: 5.3.0
+        specifier: 6.2.2-beta.0
+        version: 6.2.2-beta.0
     devDependencies:
       '@botpress/cli':
         specifier: workspace:*
@@ -4267,6 +4267,7 @@ packages:
 
   '@doist/todoist-api-typescript@3.0.3':
     resolution: {integrity: sha512-rDYE6X/xSF+b+fvRYoVyBa7EaUOSIKhTrn7/XxV3Fm2rQrK61SoImor5pyWZlMiABH44WMf+FBIh+IjGAGaX3Q==}
+    deprecated: Package renamed to @doist/todoist-sdk. Please update your dependency.
     peerDependencies:
       type-fest: ^4.12.0
 
@@ -8657,15 +8658,17 @@ packages:
   glob@10.3.10:
     resolution: {integrity: sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==}
     engines: {node: '>=16 || 14 >=14.17'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@9.3.5:
     resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
     engines: {node: '>=16 || 14 >=14.17'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -11931,23 +11934,27 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
-    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.0:
     resolution: {integrity: sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -12096,8 +12103,8 @@ packages:
     resolution: {integrity: sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==}
     engines: {node: '>=0.8.0'}
 
-  whatsapp-api-js@5.3.0:
-    resolution: {integrity: sha512-Rw2pfh0qsbQ1FT+Y4F9Lc8pfoyT80ghVE7xAXDESYknQNfjwawb/lCI3SXN/+sE9wrn7y7ob5CDPLNO9JfwsVg==}
+  whatsapp-api-js@6.2.2-beta.0:
+    resolution: {integrity: sha512-lk0iXHkK2DzM0EYbOjulgQVduU11Pq9ReIBbGmRtQQ6KfckSi4Hfn0cXqV3KXJ1gDHlgbz3U16oQwU+6h19PBA==}
     engines: {node: '>=16'}
 
   whatwg-encoding@3.1.1:
@@ -23196,7 +23203,7 @@ snapshots:
 
   websocket-extensions@0.1.4: {}
 
-  whatsapp-api-js@5.3.0: {}
+  whatsapp-api-js@6.2.2-beta.0: {}
 
   whatwg-encoding@3.1.1:
     dependencies:


### PR DESCRIPTION
## Why

`whatsapp-api-js` v5.3.0 only exposes `sendMessage(phoneId, to: string, message)`. The `ClientRecipientIdentifier` overload that FOU-328 needs to send via BSUID first appears in **6.2.2-beta.0** (mar/2026). This PR is the pre-requisite mechanical upgrade so that FOU-328 can wire up the BSUID outbound path on top of a v6 surface, with no functional change of its own.

Pinned exact `6.2.2-beta.0` instead of caret because caret on a prerelease is ambiguous — a future stable `6.2.2` could ship without the overload and silently regress us. Once stable lands, we re-broaden.

## Scope guard

Diff intentionally **contains no BSUID reference** — that's FOU-328's job. This PR only:

- Migrates all 8 `sendMessage` call sites to wrap the phone string as `{ phone }` (task spec listed 4; audit found 4 more in `sandbox.ts` and `typing-indicator.ts`).
- Bumps `INTEGRATION_VERSION` 1.1.0 → 1.2.0 (required by `check-integration-versions.yml`).

## What I audited and did not touch

Per upstream `BREAKING.md` for v5 → v6, the documented breaks are:

| Breaking change | Fork impact |
|---|---|
| `parsed` option removed from `WhatsAppAPI` ctor | Not used — `new WhatsAppAPI({ token, secure, v })` |
| Webhook `pricing` / `conversation` types reshaped | Not referenced anywhere in the integration |
| Node 18 dropped | Already on Node 22 |
| Default Graph API bumped (v23 then v24) | Fork pins its own version via `WHATSAPP.API_VERSION` |

Subpath exports (`/messages`, `/types`, `/errors`, `/emitters`) are byte-identical between 5.3.0 and 6.2.2-beta.0, so the existing imports stay put. The deep import `whatsapp-api-js/lib/utils` (for `AtLeastOne`) was already not in the exports map in v5 either, so it's not a v6 regression — left untouched.

## Stack

This PR stacks on **#5** (`feat/fou-320-bsuid`). FOU-328 will stack on this one.

## Checks

- `pnpm --filter '@stay/whatsapp-stay' check:type` ✓
- `pnpm --filter '@stay/whatsapp-stay' check:bplint` ✓ (1 pre-existing warning, not introduced here)
- `pnpm --filter '@stay/whatsapp-stay' test` ✓ 162/162

Resolves FOU-327