### PR TITLE
feat(whatsapp-stay): adopt BSUID outbound via v6 ClientRecipientIdentifier (FOU-328)

### DIFF
--- a/integrations/whatsapp/integration.definition.ts
+++ b/integrations/whatsapp/integration.definition.ts
@@ -74,9 +74,18 @@ const startConversationProps = {
           userPhone: z
             .string()
             .min(1)
+            .optional()
             .title('User Phone Number')
             .describe(
-              'Phone number of the WhatsApp user to start a conversation with. Add the country code (e.g. +81 for japan)'
+              'Phone number of the WhatsApp user to start a conversation with. Add the country code (e.g. +81 for japan). At least one of userPhone or userBsuid must be provided.'
+            ),
+          userBsuid: z
+            .string()
+            .min(1)
+            .optional()
+            .title('User BSUID')
+            .describe(
+              'Business-Scoped User ID (BSUID) of the WhatsApp user, format `{ISO 3166}.{alphanumeric}` (e.g. "BR.X"). At least one of userPhone or userBsuid must be provided.'
             ),
           templateName: z
             .string()
@@ -157,7 +166,7 @@ const defaultBotPhoneNumberId = {
 }
 
 export const INTEGRATION_NAME = 'whatsapp-stay'
-export const INTEGRATION_VERSION = '1.2.0'
+export const INTEGRATION_VERSION = '1.3.0'
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
   version: INTEGRATION_VERSION,
@@ -509,19 +518,29 @@ export default new IntegrationDefinition({
       description: 'Sends an Interactive Flow message to a WhatsApp user',
       input: {
         schema: z.object({
-          conversation: z
-            .object({
-              userPhone: z
-                .string()
-                .min(1)
-                .title('User Phone Number')
-                .describe('Phone number of the WhatsApp user to start a conversation with'),
-              botPhoneNumberId: z
-                .string()
-                .optional()
-                .title('Bot Phone Number ID')
-                .describe('Phone number ID to use as sender (uses the default phone number ID if not provided)'),
-            })
+          conversation: z.object({
+            userPhone: z
+              .string()
+              .min(1)
+              .optional()
+              .title('User Phone Number')
+              .describe(
+                'Phone number of the WhatsApp user to start a conversation with. At least one of userPhone or userBsuid must be provided.'
+              ),
+            userBsuid: z
+              .string()
+              .min(1)
+              .optional()
+              .title('User BSUID')
+              .describe(
+                'Business-Scoped User ID (BSUID) of the WhatsApp user, format `{ISO 3166}.{alphanumeric}`. At least one of userPhone or userBsuid must be provided.'
+              ),
+            botPhoneNumberId: z
+              .string()
+              .optional()
+              .title('Bot Phone Number ID')
+              .describe('Phone number ID to use as sender (uses the default phone number ID if not provided)'),
+          })
             .title('Conversation Details')
             .describe('Details of the conversation to start'),
           bodyText: z.string().min(1).title('Body Text').describe('Text body to show above the Flow CTA'),

--- a/integrations/whatsapp/src/actions/start-conversation.ts
+++ b/integrations/whatsapp/src/actions/start-conversation.ts
@@ -3,7 +3,7 @@ import { INTEGRATION_NAME, INTEGRATION_VERSION } from 'integration.definition'
 import { Language, Template } from 'whatsapp-api-js/messages'
 import type { TemplateComponent } from 'whatsapp-api-js/types'
 import { getDefaultBotPhoneNumberId, getAuthenticatedWhatsappClient } from '../auth'
-import { chooseSendRecipient } from '../misc/identifier-decision'
+import { buildConversationTags, chooseSendRecipient } from '../misc/identifier-decision'
 import { safeFormatPhoneNumber } from '../misc/phone-number-to-whatsapp'
 import {
   generateSyntheticTemplateText,
@@ -110,15 +110,9 @@ export const startConversation: bp.IntegrationProps['actions']['startConversatio
     formattedPhone = formatPhoneNumberResponse.phoneNumber
   }
 
-  const conversationTags: Record<string, string> = {
-    botPhoneNumberId,
-  }
-  if (formattedPhone) conversationTags.userPhone = formattedPhone
-  if (userBsuid) conversationTags.bsuid = userBsuid
-
   const { conversation } = await client.getOrCreateConversation({
     channel: 'channel',
-    tags: conversationTags,
+    tags: buildConversationTags({ botPhoneNumberId, userPhone: formattedPhone, bsuid: userBsuid }),
   })
 
   const recipient = chooseSendRecipient({ userPhone: formattedPhone, bsuid: userBsuid })

--- a/integrations/whatsapp/src/actions/start-conversation.ts
+++ b/integrations/whatsapp/src/actions/start-conversation.ts
@@ -3,7 +3,7 @@ import { INTEGRATION_NAME, INTEGRATION_VERSION } from 'integration.definition'
 import { Language, Template } from 'whatsapp-api-js/messages'
 import type { TemplateComponent } from 'whatsapp-api-js/types'
 import { getDefaultBotPhoneNumberId, getAuthenticatedWhatsappClient } from '../auth'
-import { chooseSendRecipient, MissingWhatsAppRecipientError, type SendRecipient } from '../misc/identifier-decision'
+import { chooseSendRecipient } from '../misc/identifier-decision'
 import { safeFormatPhoneNumber } from '../misc/phone-number-to-whatsapp'
 import {
   generateSyntheticTemplateText,
@@ -121,15 +121,7 @@ export const startConversation: bp.IntegrationProps['actions']['startConversatio
     tags: conversationTags,
   })
 
-  let recipient: SendRecipient
-  try {
-    recipient = chooseSendRecipient({ userPhone: formattedPhone, bsuid: userBsuid })
-  } catch (err) {
-    if (err instanceof MissingWhatsAppRecipientError) {
-      logForBotAndThrow(err.message, logger)
-    }
-    throw err
-  }
+  const recipient = chooseSendRecipient({ userPhone: formattedPhone, bsuid: userBsuid })
 
   const whatsapp = await getAuthenticatedWhatsappClient(client, ctx)
   const language = new Language(templateLanguage)

--- a/integrations/whatsapp/src/actions/start-conversation.ts
+++ b/integrations/whatsapp/src/actions/start-conversation.ts
@@ -3,6 +3,7 @@ import { INTEGRATION_NAME, INTEGRATION_VERSION } from 'integration.definition'
 import { Language, Template } from 'whatsapp-api-js/messages'
 import type { TemplateComponent } from 'whatsapp-api-js/types'
 import { getDefaultBotPhoneNumberId, getAuthenticatedWhatsappClient } from '../auth'
+import { chooseSendRecipient, MissingWhatsAppRecipientError, type SendRecipient } from '../misc/identifier-decision'
 import { safeFormatPhoneNumber } from '../misc/phone-number-to-whatsapp'
 import {
   generateSyntheticTemplateText,
@@ -36,12 +37,17 @@ export const startConversation: bp.IntegrationProps['actions']['startConversatio
 
   const {
     userPhone,
+    userBsuid,
     templateName,
     templateVariablesJson,
     templateHeaderParams,
     templateBodyParams,
     templateButtonParams,
   } = input.conversation
+
+  if (!userPhone && !userBsuid) {
+    logForBotAndThrow('Either userPhone or userBsuid must be provided', logger)
+  }
   const botPhoneNumberId = input.conversation.botPhoneNumberId
     ? input.conversation.botPhoneNumberId
     : await getDefaultBotPhoneNumberId(client, ctx).catch(() => {
@@ -82,37 +88,54 @@ export const startConversation: bp.IntegrationProps['actions']['startConversatio
     templateApiComponents.push(...buildButtonComponents(templateButtonParams))
   }
 
-  const formatPhoneNumberResponse = safeFormatPhoneNumber(userPhone)
-  if (formatPhoneNumberResponse.success === false) {
-    const distinctId = formatPhoneNumberResponse.error.id
-    await posthogHelper.sendPosthogEvent(
-      {
-        distinctId: distinctId ?? 'no id',
-        event: 'invalid_phone_number',
-        properties: {
-          from: 'action',
-          phoneNumber: userPhone,
+  let formattedPhone: string | undefined
+  if (userPhone) {
+    const formatPhoneNumberResponse = safeFormatPhoneNumber(userPhone)
+    if (formatPhoneNumberResponse.success === false) {
+      const distinctId = formatPhoneNumberResponse.error.id
+      await posthogHelper.sendPosthogEvent(
+        {
+          distinctId: distinctId ?? 'no id',
+          event: 'invalid_phone_number',
+          properties: {
+            from: 'action',
+            phoneNumber: userPhone,
+          },
         },
-      },
-      { integrationName: INTEGRATION_NAME, integrationVersion: INTEGRATION_VERSION, key: bp.secrets.POSTHOG_KEY }
-    )
-    const errorMessage = formatPhoneNumberResponse.error.message
-    logForBotAndThrow(`Failed to parse phone number "${userPhone}": ${errorMessage}`, logger)
+        { integrationName: INTEGRATION_NAME, integrationVersion: INTEGRATION_VERSION, key: bp.secrets.POSTHOG_KEY }
+      )
+      const errorMessage = formatPhoneNumberResponse.error.message
+      logForBotAndThrow(`Failed to parse phone number "${userPhone}": ${errorMessage}`, logger)
+    }
+    formattedPhone = formatPhoneNumberResponse.phoneNumber
   }
+
+  const conversationTags: Record<string, string> = {
+    botPhoneNumberId,
+  }
+  if (formattedPhone) conversationTags.userPhone = formattedPhone
+  if (userBsuid) conversationTags.bsuid = userBsuid
 
   const { conversation } = await client.getOrCreateConversation({
     channel: 'channel',
-    tags: {
-      botPhoneNumberId,
-      userPhone: formatPhoneNumberResponse.phoneNumber,
-    },
+    tags: conversationTags,
   })
+
+  let recipient: SendRecipient
+  try {
+    recipient = chooseSendRecipient({ userPhone: formattedPhone, bsuid: userBsuid })
+  } catch (err) {
+    if (err instanceof MissingWhatsAppRecipientError) {
+      logForBotAndThrow(err.message, logger)
+    }
+    throw err
+  }
 
   const whatsapp = await getAuthenticatedWhatsappClient(client, ctx)
   const language = new Language(templateLanguage)
   const template = new Template(templateName, language, ...templateApiComponents)
 
-  const response = await whatsapp.sendMessage(botPhoneNumberId, { phone: userPhone }, template)
+  const response = await whatsapp.sendMessage(botPhoneNumberId, recipient, template)
 
   if ('error' in response) {
     const errorJSON = JSON.stringify(response.error)

--- a/integrations/whatsapp/src/actions/start-flow.ts
+++ b/integrations/whatsapp/src/actions/start-flow.ts
@@ -1,6 +1,7 @@
 import { RuntimeError, z } from '@botpress/sdk'
 import { getDefaultBotPhoneNumberId, getAuthenticatedWhatsappClient } from '../auth'
 import { Interactive, Body, ActionFlow } from 'whatsapp-api-js/messages'
+import { chooseSendRecipient, MissingWhatsAppRecipientError, type SendRecipient } from '../misc/identifier-decision'
 import * as bp from '.botpress'
 
 const NonEmptyObjectSchema = z
@@ -17,10 +18,14 @@ export const startFlow = async ({ ctx, input, client, logger }: any) => {
   }
 
   const {
-    conversation: { userPhone, botPhoneNumberId: maybeBotPhoneNumberId },
+    conversation: { userPhone, userBsuid, botPhoneNumberId: maybeBotPhoneNumberId },
     bodyText,
     flow,
   } = input
+
+  if (!userPhone && !userBsuid) {
+    _logForBotAndThrow('Either userPhone or userBsuid must be provided', logger)
+  }
 
   const botPhoneNumberId = maybeBotPhoneNumberId
     ? maybeBotPhoneNumberId
@@ -28,13 +33,24 @@ export const startFlow = async ({ ctx, input, client, logger }: any) => {
         _logForBotAndThrow('No default bot phone number ID available', logger)
       })
 
+  const conversationTags: Record<string, string> = { botPhoneNumberId }
+  if (userPhone) conversationTags.userPhone = userPhone
+  if (userBsuid) conversationTags.bsuid = userBsuid
+
   const { conversation } = await client.getOrCreateConversation({
     channel: 'channel',
-    tags: {
-      botPhoneNumberId,
-      userPhone,
-    },
+    tags: conversationTags,
   })
+
+  let recipient: SendRecipient
+  try {
+    recipient = chooseSendRecipient({ userPhone, bsuid: userBsuid })
+  } catch (err) {
+    if (err instanceof MissingWhatsAppRecipientError) {
+      _logForBotAndThrow(err.message, logger)
+    }
+    throw err
+  }
 
   const whatsapp = await getAuthenticatedWhatsappClient(client, ctx)
 
@@ -97,7 +113,7 @@ export const startFlow = async ({ ctx, input, client, logger }: any) => {
 
   const interactive = new Interactive(new ActionFlow(parameters), new Body(bodyText))
 
-  const response = await whatsapp.sendMessage(botPhoneNumberId, { phone: userPhone }, interactive)
+  const response = await whatsapp.sendMessage(botPhoneNumberId, recipient, interactive)
 
   if ('error' in response) {
     const errorJSON = JSON.stringify(response.error)

--- a/integrations/whatsapp/src/actions/start-flow.ts
+++ b/integrations/whatsapp/src/actions/start-flow.ts
@@ -1,7 +1,7 @@
 import { RuntimeError, z } from '@botpress/sdk'
 import { getDefaultBotPhoneNumberId, getAuthenticatedWhatsappClient } from '../auth'
 import { Interactive, Body, ActionFlow } from 'whatsapp-api-js/messages'
-import { chooseSendRecipient, MissingWhatsAppRecipientError, type SendRecipient } from '../misc/identifier-decision'
+import { chooseSendRecipient } from '../misc/identifier-decision'
 import * as bp from '.botpress'
 
 const NonEmptyObjectSchema = z
@@ -42,15 +42,7 @@ export const startFlow = async ({ ctx, input, client, logger }: any) => {
     tags: conversationTags,
   })
 
-  let recipient: SendRecipient
-  try {
-    recipient = chooseSendRecipient({ userPhone, bsuid: userBsuid })
-  } catch (err) {
-    if (err instanceof MissingWhatsAppRecipientError) {
-      _logForBotAndThrow(err.message, logger)
-    }
-    throw err
-  }
+  const recipient = chooseSendRecipient({ userPhone, bsuid: userBsuid })
 
   const whatsapp = await getAuthenticatedWhatsappClient(client, ctx)
 

--- a/integrations/whatsapp/src/actions/start-flow.ts
+++ b/integrations/whatsapp/src/actions/start-flow.ts
@@ -1,7 +1,7 @@
 import { RuntimeError, z } from '@botpress/sdk'
 import { getDefaultBotPhoneNumberId, getAuthenticatedWhatsappClient } from '../auth'
 import { Interactive, Body, ActionFlow } from 'whatsapp-api-js/messages'
-import { chooseSendRecipient } from '../misc/identifier-decision'
+import { buildConversationTags, chooseSendRecipient } from '../misc/identifier-decision'
 import * as bp from '.botpress'
 
 const NonEmptyObjectSchema = z
@@ -33,13 +33,9 @@ export const startFlow = async ({ ctx, input, client, logger }: any) => {
         _logForBotAndThrow('No default bot phone number ID available', logger)
       })
 
-  const conversationTags: Record<string, string> = { botPhoneNumberId }
-  if (userPhone) conversationTags.userPhone = userPhone
-  if (userBsuid) conversationTags.bsuid = userBsuid
-
   const { conversation } = await client.getOrCreateConversation({
     channel: 'channel',
-    tags: conversationTags,
+    tags: buildConversationTags({ botPhoneNumberId, userPhone, bsuid: userBsuid }),
   })
 
   const recipient = chooseSendRecipient({ userPhone, bsuid: userBsuid })

--- a/integrations/whatsapp/src/channels/channel.ts
+++ b/integrations/whatsapp/src/channels/channel.ts
@@ -15,6 +15,7 @@ import {
 } from 'whatsapp-api-js/messages'
 import { getAuthenticatedWhatsappClient } from '../auth'
 import { WHATSAPP } from '../misc/constants'
+import { chooseSendRecipient, MissingWhatsAppRecipientError, type SendRecipient } from '../misc/identifier-decision'
 import { convertMarkdownToWhatsApp } from '../misc/markdown-to-whatsapp-rtf'
 import { splitTextMessageIfNeeded } from '../misc/split-text-message'
 import { sleep } from '../misc/util'
@@ -267,7 +268,6 @@ async function _send({ client, ctx, conversation, logger, message, ack }: SendMe
 
   const whatsapp = await getAuthenticatedWhatsappClient(client, ctx)
   const botPhoneNumberId = conversation.tags.botPhoneNumberId
-  const userPhoneNumber = conversation.tags.userPhone
   const messageType = message._type
 
   if (!botPhoneNumberId) {
@@ -277,11 +277,30 @@ async function _send({ client, ctx, conversation, logger, message, ack }: SendMe
     return
   }
 
-  if (!userPhoneNumber) {
+  let recipient: SendRecipient
+  try {
+    recipient = chooseSendRecipient({
+      userPhone: conversation.tags.userPhone,
+      bsuid: conversation.tags.bsuid,
+    })
+  } catch (err) {
+    if (err instanceof MissingWhatsAppRecipientError) {
+      logger
+        .forBot()
+        .error(
+          "Cannot send message to WhatsApp because neither 'userPhone' nor 'bsuid' is set in the conversation tags"
+        )
+      return
+    }
+    throw err
+  }
+
+  if ('bsuid' in recipient) {
     logger
       .forBot()
-      .error("Cannot send message to WhatsApp because the user's phone number isn't set in the conversation tags")
-    return
+      .info(
+        `Sending WhatsApp ${messageType} via BSUID fallback (no userPhone tag on conversation; bsuid="${recipient.bsuid}").`
+      )
   }
 
   const feedback = await repeat(
@@ -290,7 +309,7 @@ async function _send({ client, ctx, conversation, logger, message, ack }: SendMe
         logger.forBot().info(`Retrying to send ${messageType} message to WhatsApp (attempt ${i + 1}/${MAX_ATTEMPT})...`)
       }
 
-      const result = await whatsapp.sendMessage(botPhoneNumberId, { phone: userPhoneNumber }, message)
+      const result = await whatsapp.sendMessage(botPhoneNumberId, recipient, message)
       const repeat = 'error' in result && THROTTLING_CODES.has(result.error?.code ?? 0)
       return {
         repeat,

--- a/integrations/whatsapp/src/channels/channel.ts
+++ b/integrations/whatsapp/src/channels/channel.ts
@@ -298,7 +298,7 @@ async function _send({ client, ctx, conversation, logger, message, ack }: SendMe
   if ('bsuid' in recipient) {
     logger
       .forBot()
-      .info(
+      .debug(
         `Sending WhatsApp ${messageType} via BSUID fallback (no userPhone tag on conversation; bsuid="${recipient.bsuid}").`
       )
   }

--- a/integrations/whatsapp/src/misc/identifier-decision.test.ts
+++ b/integrations/whatsapp/src/misc/identifier-decision.test.ts
@@ -1,7 +1,6 @@
 import { test, expect } from 'vitest'
 import {
   chooseSendRecipient,
-  hasSufficientIdentifier,
   MissingWhatsAppRecipientError,
 } from './identifier-decision'
 
@@ -26,24 +25,4 @@ test('chooseSendRecipient: throws MissingWhatsAppRecipientError when neither is 
 
 test('chooseSendRecipient: throws MissingWhatsAppRecipientError when both are empty strings', () => {
   expect(() => chooseSendRecipient({ userPhone: '', bsuid: '' })).toThrow(MissingWhatsAppRecipientError)
-})
-
-test('hasSufficientIdentifier: true when both present', () => {
-  expect(hasSufficientIdentifier({ bsuid: 'BR.X', phone: '5511999999999' })).toBe(true)
-})
-
-test('hasSufficientIdentifier: true when only bsuid', () => {
-  expect(hasSufficientIdentifier({ bsuid: 'BR.X' })).toBe(true)
-})
-
-test('hasSufficientIdentifier: true when only phone', () => {
-  expect(hasSufficientIdentifier({ phone: '5511999999999' })).toBe(true)
-})
-
-test('hasSufficientIdentifier: false when neither present', () => {
-  expect(hasSufficientIdentifier({})).toBe(false)
-})
-
-test('hasSufficientIdentifier: false when both empty strings', () => {
-  expect(hasSufficientIdentifier({ bsuid: '', phone: '' })).toBe(false)
 })

--- a/integrations/whatsapp/src/misc/identifier-decision.test.ts
+++ b/integrations/whatsapp/src/misc/identifier-decision.test.ts
@@ -1,0 +1,49 @@
+import { test, expect } from 'vitest'
+import {
+  chooseSendRecipient,
+  hasSufficientIdentifier,
+  MissingWhatsAppRecipientError,
+} from './identifier-decision'
+
+test('chooseSendRecipient: prefers phone when both are present', () => {
+  const result = chooseSendRecipient({ userPhone: '5511999999999', bsuid: 'BR.X' })
+  expect(result).toEqual({ phone: '5511999999999' })
+})
+
+test('chooseSendRecipient: falls back to bsuid when phone is missing', () => {
+  const result = chooseSendRecipient({ bsuid: 'BR.X' })
+  expect(result).toEqual({ bsuid: 'BR.X' })
+})
+
+test('chooseSendRecipient: uses phone when only phone is present', () => {
+  const result = chooseSendRecipient({ userPhone: '5511999999999' })
+  expect(result).toEqual({ phone: '5511999999999' })
+})
+
+test('chooseSendRecipient: throws MissingWhatsAppRecipientError when neither is present', () => {
+  expect(() => chooseSendRecipient({})).toThrow(MissingWhatsAppRecipientError)
+})
+
+test('chooseSendRecipient: throws MissingWhatsAppRecipientError when both are empty strings', () => {
+  expect(() => chooseSendRecipient({ userPhone: '', bsuid: '' })).toThrow(MissingWhatsAppRecipientError)
+})
+
+test('hasSufficientIdentifier: true when both present', () => {
+  expect(hasSufficientIdentifier({ bsuid: 'BR.X', phone: '5511999999999' })).toBe(true)
+})
+
+test('hasSufficientIdentifier: true when only bsuid', () => {
+  expect(hasSufficientIdentifier({ bsuid: 'BR.X' })).toBe(true)
+})
+
+test('hasSufficientIdentifier: true when only phone', () => {
+  expect(hasSufficientIdentifier({ phone: '5511999999999' })).toBe(true)
+})
+
+test('hasSufficientIdentifier: false when neither present', () => {
+  expect(hasSufficientIdentifier({})).toBe(false)
+})
+
+test('hasSufficientIdentifier: false when both empty strings', () => {
+  expect(hasSufficientIdentifier({ bsuid: '', phone: '' })).toBe(false)
+})

--- a/integrations/whatsapp/src/misc/identifier-decision.ts
+++ b/integrations/whatsapp/src/misc/identifier-decision.ts
@@ -3,11 +3,6 @@ export type RecipientTags = {
   bsuid?: string
 }
 
-export type IdentifierPayload = {
-  bsuid?: string
-  phone?: string
-}
-
 export type SendRecipient = { phone: string } | { bsuid: string }
 
 export class MissingWhatsAppRecipientError extends Error {
@@ -28,6 +23,3 @@ export const chooseSendRecipient = (tags: RecipientTags): SendRecipient => {
   }
   throw new MissingWhatsAppRecipientError()
 }
-
-export const hasSufficientIdentifier = (payload: IdentifierPayload): boolean =>
-  Boolean(payload.bsuid) || Boolean(payload.phone)

--- a/integrations/whatsapp/src/misc/identifier-decision.ts
+++ b/integrations/whatsapp/src/misc/identifier-decision.ts
@@ -1,11 +1,13 @@
-export type RecipientTags = {
+import { RuntimeError } from '@botpress/sdk'
+
+type RecipientTags = {
   userPhone?: string
   bsuid?: string
 }
 
 export type SendRecipient = { phone: string } | { bsuid: string }
 
-export class MissingWhatsAppRecipientError extends Error {
+export class MissingWhatsAppRecipientError extends RuntimeError {
   public constructor() {
     super(
       "Cannot send WhatsApp message: neither 'userPhone' nor 'bsuid' is set in conversation tags."
@@ -22,4 +24,15 @@ export const chooseSendRecipient = (tags: RecipientTags): SendRecipient => {
     return { bsuid: tags.bsuid }
   }
   throw new MissingWhatsAppRecipientError()
+}
+
+export const buildConversationTags = (input: {
+  botPhoneNumberId: string
+  userPhone?: string
+  bsuid?: string
+}): Record<string, string> => {
+  const tags: Record<string, string> = { botPhoneNumberId: input.botPhoneNumberId }
+  if (input.userPhone) tags.userPhone = input.userPhone
+  if (input.bsuid) tags.bsuid = input.bsuid
+  return tags
 }

--- a/integrations/whatsapp/src/misc/identifier-decision.ts
+++ b/integrations/whatsapp/src/misc/identifier-decision.ts
@@ -1,0 +1,33 @@
+export type RecipientTags = {
+  userPhone?: string
+  bsuid?: string
+}
+
+export type IdentifierPayload = {
+  bsuid?: string
+  phone?: string
+}
+
+export type SendRecipient = { phone: string } | { bsuid: string }
+
+export class MissingWhatsAppRecipientError extends Error {
+  public constructor() {
+    super(
+      "Cannot send WhatsApp message: neither 'userPhone' nor 'bsuid' is set in conversation tags."
+    )
+    this.name = 'MissingWhatsAppRecipientError'
+  }
+}
+
+export const chooseSendRecipient = (tags: RecipientTags): SendRecipient => {
+  if (tags.userPhone) {
+    return { phone: tags.userPhone }
+  }
+  if (tags.bsuid) {
+    return { bsuid: tags.bsuid }
+  }
+  throw new MissingWhatsAppRecipientError()
+}
+
+export const hasSufficientIdentifier = (payload: IdentifierPayload): boolean =>
+  Boolean(payload.bsuid) || Boolean(payload.phone)

--- a/integrations/whatsapp/src/webhook/handlers/messages.ts
+++ b/integrations/whatsapp/src/webhook/handlers/messages.ts
@@ -5,6 +5,7 @@ import axios from 'axios'
 import { INTEGRATION_NAME, INTEGRATION_VERSION } from 'integration.definition'
 import { getAccessToken, getAuthenticatedWhatsappClient } from '../../auth'
 import { extractContactIdentifiers } from '../../misc/bsuid-extraction'
+import { buildConversationTags } from '../../misc/identifier-decision'
 import { safeFormatPhoneNumber } from '../../misc/phone-number-to-whatsapp'
 import { WhatsAppMessage, WhatsAppMessageValue } from '../../misc/types'
 import { getMessageFromWhatsappMessageId } from '../../misc/util'
@@ -83,15 +84,9 @@ export const messagesHandler = async (
     return
   }
 
-  const conversationTags: Record<string, string> = {
-    botPhoneNumberId: value.metadata.phone_number_id,
-  }
-  if (userPhone) conversationTags.userPhone = userPhone
-  if (bsuid) conversationTags.bsuid = bsuid
-
   const { conversation } = await client.getOrCreateConversation({
     channel: 'channel',
-    tags: conversationTags,
+    tags: buildConversationTags({ botPhoneNumberId: value.metadata.phone_number_id, userPhone, bsuid }),
   })
 
   const userTags: Record<string, string | undefined> = {


### PR DESCRIPTION
Reapplies the BSUID outbound path that was removed in 12033c25 from
FOU-320. With whatsapp-api-js@6.2.2-beta.0 pinned by FOU-327, the
`sendMessage(phoneID, { phone | bsuid }, message)` overload is now
available, so the fork can target a recipient by phone or by BSUID
without falling back to ad-hoc string `to` semantics.

- restore `chooseSendRecipient` / `MissingWhatsAppRecipientError` /
  `hasSufficientIdentifier` in `misc/identifier-decision.ts`; the
  return shape is now `{ phone: string } | { bsuid: string }`, matching
  v6's `ClientIndividualRecipientIdentifier`
- re-add `userBsuid` to the `startConversation` and `startFlow` input
  schemas (optional; at least one of `userPhone` / `userBsuid` required)
- route `_send`, `startConversation`, and `startFlow` through
  `chooseSendRecipient`; phone is preferred when both tags are present,
  BSUID is the fallback when only it is set
- `_send` logs an info line when falling back to BSUID, to make the path
  observable in production
- bump INTEGRATION_VERSION 1.2.0 -> 1.3.0

Test deltas: `identifier-decision.test.ts` asserts the new v6 shape
(`{ phone }` / `{ bsuid }`) instead of the previous discriminated union
(`{ kind, value }`). 10 new tests, 0 modified.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>