### PR TITLE
fix(whatsapp-stay): accept empty-string userPhone/userBsuid in send actions (FOU-339)

### DIFF
--- a/integrations/whatsapp/integration.definition.ts
+++ b/integrations/whatsapp/integration.definition.ts
@@ -73,7 +73,6 @@ const startConversationProps = {
         .object({
           userPhone: z
             .string()
-            .min(1)
             .optional()
             .title('User Phone Number')
             .describe(
@@ -81,7 +80,6 @@ const startConversationProps = {
             ),
           userBsuid: z
             .string()
-            .min(1)
             .optional()
             .title('User BSUID')
             .describe(
@@ -166,7 +164,7 @@ const defaultBotPhoneNumberId = {
 }
 
 export const INTEGRATION_NAME = 'whatsapp-stay'
-export const INTEGRATION_VERSION = '1.3.0'
+export const INTEGRATION_VERSION = '1.3.1'
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
   version: INTEGRATION_VERSION,
@@ -521,7 +519,6 @@ export default new IntegrationDefinition({
           conversation: z.object({
             userPhone: z
               .string()
-              .min(1)
               .optional()
               .title('User Phone Number')
               .describe(
@@ -529,7 +526,6 @@ export default new IntegrationDefinition({
               ),
             userBsuid: z
               .string()
-              .min(1)
               .optional()
               .title('User BSUID')
               .describe(

--- a/integrations/whatsapp/src/misc/identifier-decision.test.ts
+++ b/integrations/whatsapp/src/misc/identifier-decision.test.ts
@@ -26,3 +26,8 @@ test('chooseSendRecipient: throws MissingWhatsAppRecipientError when neither is 
 test('chooseSendRecipient: throws MissingWhatsAppRecipientError when both are empty strings', () => {
   expect(() => chooseSendRecipient({ userPhone: '', bsuid: '' })).toThrow(MissingWhatsAppRecipientError)
 })
+
+test('chooseSendRecipient: falls back to bsuid when phone is an empty string', () => {
+  const result = chooseSendRecipient({ userPhone: '', bsuid: 'BR.X' })
+  expect(result).toEqual({ bsuid: 'BR.X' })
+})


### PR DESCRIPTION
## Problema

Ao enviar Flow/Template, o Botpress rejeitava a action antes mesmo de executá-la:

```
invalid input for action "stay/whatsapp-stay:startFlow":
data/conversation/userBsuid must NOT have fewer than 1 characters
```

Os schemas de input de `startConversation` e `startFlow` declaravam `userPhone`/`userBsuid` como `z.string().min(1).optional()`, que vira `minLength: 1` no JSON Schema. O Botpress valida o input da action com **AJV antes** de chamar a integração, então `.optional()` aceita o campo **ausente/`undefined`**, mas **não** uma string vazia.

O Studio serializa campos opcionais em branco/mapeados a uma variável vazia como `""` (não omite a chave). Resultado: cards como o **"Start Flow"** do flow **WithdrawalBank** enviavam `userBsuid: ""` → AJV rejeitava → a action nunca rodava. Cards que simplesmente não têm o campo (chave ausente) seguiam funcionando — daí a diferença de comportamento entre cards "iguais".

## Mudança

Remover `.min(1)` de `userPhone` e `userBsuid` nas duas actions. String vazia passa a ser aceita na validação de schema, e o handler **já trata `""` como ausente** (checagens truthy em `chooseSendRecipient` / `buildConversationTags`). A garantia "pelo menos um identificador" continua em runtime via `MissingWhatsAppRecipientError`.

Bump de versão `1.3.0 → 1.3.1`.

## Testes

- `identifier-decision.test.ts`: adicionado caso `phone vazio + bsuid válido → usa bsuid` (6/6 verdes).
- Suíte de unit da integração roda verde no escopo afetado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)