### PR TITLE
feat(whatsapp-stay): add Statsig feature toggle for inbound forwarding (FOU-550)

### DIFF
--- a/integrations/whatsapp/integration.definition.ts
+++ b/integrations/whatsapp/integration.definition.ts
@@ -717,6 +717,9 @@ export default new IntegrationDefinition({
     SANDBOX_PHONE_NUMBER_ID: {
       description: 'Phone number ID of the Sandbox WhatsApp Business profile',
     },
+    STATSIG_API_KEY: {
+      description: 'Statsig server SDK key used to evaluate feature toggles (e.g. inbound forwarding to Darwin)',
+    },
   },
   entities: {
     proactiveConversation: {

--- a/integrations/whatsapp/package.json
+++ b/integrations/whatsapp/package.json
@@ -18,6 +18,7 @@
     "marked": "^15.0.1",
     "preact": "^10.26.6",
     "preact-render-to-string": "^6.5.13",
+    "statsig-node": "^6.5.1",
     "whatsapp-api-js": "6.2.2-beta.0"
   },
   "devDependencies": {

--- a/integrations/whatsapp/src/misc/feature-toggle.test.ts
+++ b/integrations/whatsapp/src/misc/feature-toggle.test.ts
@@ -1,0 +1,84 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+
+const initialize = vi.fn()
+const checkGateSync = vi.fn()
+
+vi.mock('statsig-node', () => ({
+  default: {
+    initialize: (...args: unknown[]) => initialize(...args),
+    checkGateSync: (...args: unknown[]) => checkGateSync(...args),
+  },
+}))
+
+const secrets = { STATSIG_API_KEY: '' }
+
+vi.mock('.botpress', () => ({
+  get secrets() {
+    return secrets
+  },
+}))
+
+const PHONE = '5511999999999'
+
+function buildLogger() {
+  const error = vi.fn()
+  const logger = { forBot: () => ({ error }) }
+  return { logger, error }
+}
+
+describe('isInboundForwardingEnabled', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+    secrets.STATSIG_API_KEY = ''
+  })
+
+  test('returns false without calling Statsig when STATSIG_API_KEY is missing', async () => {
+    secrets.STATSIG_API_KEY = ''
+    const { isInboundForwardingEnabled } = await import('./feature-toggle')
+    const { logger } = buildLogger()
+
+    const result = await isInboundForwardingEnabled(PHONE, logger as never)
+
+    expect(result).toBe(false)
+    expect(initialize).not.toHaveBeenCalled()
+    expect(checkGateSync).not.toHaveBeenCalled()
+  })
+
+  test('returns true when gate is on', async () => {
+    secrets.STATSIG_API_KEY = 'secret-key'
+    checkGateSync.mockReturnValue(true)
+    const { isInboundForwardingEnabled, INBOUND_FORWARDING_GATE } = await import('./feature-toggle')
+    const { logger } = buildLogger()
+
+    const result = await isInboundForwardingEnabled(PHONE, logger as never)
+
+    expect(result).toBe(true)
+    expect(checkGateSync).toHaveBeenCalledWith({ userID: PHONE }, INBOUND_FORWARDING_GATE)
+  })
+
+  test('returns false when gate is off', async () => {
+    secrets.STATSIG_API_KEY = 'secret-key'
+    checkGateSync.mockReturnValue(false)
+    const { isInboundForwardingEnabled } = await import('./feature-toggle')
+    const { logger } = buildLogger()
+
+    const result = await isInboundForwardingEnabled(PHONE, logger as never)
+
+    expect(result).toBe(false)
+  })
+
+  test('returns false and logs when checkGate throws', async () => {
+    secrets.STATSIG_API_KEY = 'secret-key'
+    checkGateSync.mockImplementation(() => {
+      throw new Error('boom')
+    })
+    const { isInboundForwardingEnabled } = await import('./feature-toggle')
+    const { logger, error } = buildLogger()
+
+    const result = await isInboundForwardingEnabled(PHONE, logger as never)
+
+    expect(result).toBe(false)
+    expect(error).toHaveBeenCalled()
+  })
+})

--- a/integrations/whatsapp/src/misc/feature-toggle.test.ts
+++ b/integrations/whatsapp/src/misc/feature-toggle.test.ts
@@ -1,21 +1,10 @@
 import { describe, test, expect, beforeEach, vi } from 'vitest'
+import { isInboundForwardingEnabled, INBOUND_FORWARDING_GATE } from './feature-toggle'
 
-const initialize = vi.fn()
-const checkGateSync = vi.fn()
+const isGateEnabled = vi.fn()
 
-vi.mock('statsig-node', () => ({
-  default: {
-    initialize: (...args: unknown[]) => initialize(...args),
-    checkGateSync: (...args: unknown[]) => checkGateSync(...args),
-  },
-}))
-
-const secrets = { STATSIG_API_KEY: '' }
-
-vi.mock('.botpress', () => ({
-  get secrets() {
-    return secrets
-  },
+vi.mock('./statsig', () => ({
+  isGateEnabled: (...args: unknown[]) => isGateEnabled(...args),
 }))
 
 const PHONE = '5511999999999'
@@ -23,62 +12,29 @@ const PHONE = '5511999999999'
 function buildLogger() {
   const error = vi.fn()
   const logger = { forBot: () => ({ error }) }
-  return { logger, error }
+  return { logger }
 }
 
 describe('isInboundForwardingEnabled', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.resetModules()
-    secrets.STATSIG_API_KEY = ''
   })
 
-  test('returns false without calling Statsig when STATSIG_API_KEY is missing', async () => {
-    secrets.STATSIG_API_KEY = ''
-    const { isInboundForwardingEnabled } = await import('./feature-toggle')
+  test('delegates to isGateEnabled with the inbound forwarding gate and the phone as userID', async () => {
+    isGateEnabled.mockResolvedValue(true)
     const { logger } = buildLogger()
 
-    const result = await isInboundForwardingEnabled(PHONE, logger as never)
+    await isInboundForwardingEnabled(PHONE, logger as never)
 
-    expect(result).toBe(false)
-    expect(initialize).not.toHaveBeenCalled()
-    expect(checkGateSync).not.toHaveBeenCalled()
+    expect(isGateEnabled).toHaveBeenCalledWith(INBOUND_FORWARDING_GATE, PHONE, logger)
   })
 
-  test('returns true when gate is on', async () => {
-    secrets.STATSIG_API_KEY = 'secret-key'
-    checkGateSync.mockReturnValue(true)
-    const { isInboundForwardingEnabled, INBOUND_FORWARDING_GATE } = await import('./feature-toggle')
+  test('returns the result of isGateEnabled', async () => {
+    isGateEnabled.mockResolvedValue(true)
     const { logger } = buildLogger()
 
     const result = await isInboundForwardingEnabled(PHONE, logger as never)
 
     expect(result).toBe(true)
-    expect(checkGateSync).toHaveBeenCalledWith({ userID: PHONE }, INBOUND_FORWARDING_GATE)
-  })
-
-  test('returns false when gate is off', async () => {
-    secrets.STATSIG_API_KEY = 'secret-key'
-    checkGateSync.mockReturnValue(false)
-    const { isInboundForwardingEnabled } = await import('./feature-toggle')
-    const { logger } = buildLogger()
-
-    const result = await isInboundForwardingEnabled(PHONE, logger as never)
-
-    expect(result).toBe(false)
-  })
-
-  test('returns false and logs when checkGate throws', async () => {
-    secrets.STATSIG_API_KEY = 'secret-key'
-    checkGateSync.mockImplementation(() => {
-      throw new Error('boom')
-    })
-    const { isInboundForwardingEnabled } = await import('./feature-toggle')
-    const { logger, error } = buildLogger()
-
-    const result = await isInboundForwardingEnabled(PHONE, logger as never)
-
-    expect(result).toBe(false)
-    expect(error).toHaveBeenCalled()
   })
 })

--- a/integrations/whatsapp/src/misc/feature-toggle.ts
+++ b/integrations/whatsapp/src/misc/feature-toggle.ts
@@ -1,25 +1,8 @@
-import statsig from 'statsig-node'
 import * as bp from '.botpress'
+import { isGateEnabled } from './statsig'
 
 export const INBOUND_FORWARDING_GATE = 'botpress-whatsapp-events-forwarding'
 
-let initialized = false
-
 export async function isInboundForwardingEnabled(phone: string, logger: bp.Logger): Promise<boolean> {
-  const apiKey = bp.secrets.STATSIG_API_KEY
-  if (!apiKey) {
-    return false
-  }
-
-  try {
-    if (!initialized) {
-      await statsig.initialize(apiKey)
-      initialized = true
-    }
-    return statsig.checkGateSync({ userID: phone }, INBOUND_FORWARDING_GATE)
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
-    logger.forBot().error(`Failed to evaluate inbound forwarding feature toggle: ${message}`)
-    return false
-  }
+  return isGateEnabled(INBOUND_FORWARDING_GATE, phone, logger)
 }

--- a/integrations/whatsapp/src/misc/feature-toggle.ts
+++ b/integrations/whatsapp/src/misc/feature-toggle.ts
@@ -1,0 +1,24 @@
+import statsig from 'statsig-node'
+import * as bp from '.botpress'
+
+export const INBOUND_FORWARDING_GATE = 'botpress-whatsapp-events-forwarding'
+
+let initialized = false
+
+export async function isInboundForwardingEnabled(phone: string, logger: bp.Logger): Promise<boolean> {
+  const apiKey = bp.secrets.STATSIG_API_KEY
+  if (!apiKey) {
+    return false
+  }
+
+  try {
+    if (!initialized) {
+      await statsig.initialize(apiKey)
+      initialized = true
+    }
+    return statsig.checkGateSync({ userID: phone }, INBOUND_FORWARDING_GATE)
+  } catch (error) {
+    logger.forBot().error(`Failed to evaluate inbound forwarding feature toggle: ${error}`)
+    return false
+  }
+}

--- a/integrations/whatsapp/src/misc/feature-toggle.ts
+++ b/integrations/whatsapp/src/misc/feature-toggle.ts
@@ -18,7 +18,8 @@ export async function isInboundForwardingEnabled(phone: string, logger: bp.Logge
     }
     return statsig.checkGateSync({ userID: phone }, INBOUND_FORWARDING_GATE)
   } catch (error) {
-    logger.forBot().error(`Failed to evaluate inbound forwarding feature toggle: ${error}`)
+    const message = error instanceof Error ? error.message : String(error)
+    logger.forBot().error(`Failed to evaluate inbound forwarding feature toggle: ${message}`)
     return false
   }
 }

--- a/integrations/whatsapp/src/misc/statsig.test.ts
+++ b/integrations/whatsapp/src/misc/statsig.test.ts
@@ -1,0 +1,85 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+
+const initialize = vi.fn()
+const checkGateSync = vi.fn()
+
+vi.mock('statsig-node', () => ({
+  default: {
+    initialize: (...args: unknown[]) => initialize(...args),
+    checkGateSync: (...args: unknown[]) => checkGateSync(...args),
+  },
+}))
+
+const secrets = { STATSIG_API_KEY: '' }
+
+vi.mock('.botpress', () => ({
+  get secrets() {
+    return secrets
+  },
+}))
+
+const GATE = 'some-feature-gate'
+const USER_ID = '5511999999999'
+
+function buildLogger() {
+  const error = vi.fn()
+  const logger = { forBot: () => ({ error }) }
+  return { logger, error }
+}
+
+describe('isGateEnabled', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+    secrets.STATSIG_API_KEY = ''
+  })
+
+  test('returns false without calling Statsig when STATSIG_API_KEY is missing', async () => {
+    secrets.STATSIG_API_KEY = ''
+    const { isGateEnabled } = await import('./statsig')
+    const { logger } = buildLogger()
+
+    const result = await isGateEnabled(GATE, USER_ID, logger as never)
+
+    expect(result).toBe(false)
+    expect(initialize).not.toHaveBeenCalled()
+    expect(checkGateSync).not.toHaveBeenCalled()
+  })
+
+  test('returns true when gate is on', async () => {
+    secrets.STATSIG_API_KEY = 'secret-key'
+    checkGateSync.mockReturnValue(true)
+    const { isGateEnabled } = await import('./statsig')
+    const { logger } = buildLogger()
+
+    const result = await isGateEnabled(GATE, USER_ID, logger as never)
+
+    expect(result).toBe(true)
+    expect(checkGateSync).toHaveBeenCalledWith({ userID: USER_ID }, GATE)
+  })
+
+  test('returns false when gate is off', async () => {
+    secrets.STATSIG_API_KEY = 'secret-key'
+    checkGateSync.mockReturnValue(false)
+    const { isGateEnabled } = await import('./statsig')
+    const { logger } = buildLogger()
+
+    const result = await isGateEnabled(GATE, USER_ID, logger as never)
+
+    expect(result).toBe(false)
+  })
+
+  test('returns false and logs when checkGate throws', async () => {
+    secrets.STATSIG_API_KEY = 'secret-key'
+    checkGateSync.mockImplementation(() => {
+      throw new Error('boom')
+    })
+    const { isGateEnabled } = await import('./statsig')
+    const { logger, error } = buildLogger()
+
+    const result = await isGateEnabled(GATE, USER_ID, logger as never)
+
+    expect(result).toBe(false)
+    expect(error).toHaveBeenCalled()
+  })
+})

--- a/integrations/whatsapp/src/misc/statsig.ts
+++ b/integrations/whatsapp/src/misc/statsig.ts
@@ -1,0 +1,23 @@
+import statsig from 'statsig-node'
+import * as bp from '.botpress'
+
+let initialized = false
+
+export async function isGateEnabled(gateName: string, userID: string, logger: bp.Logger): Promise<boolean> {
+  const apiKey = bp.secrets.STATSIG_API_KEY
+  if (!apiKey) {
+    return false
+  }
+
+  try {
+    if (!initialized) {
+      await statsig.initialize(apiKey)
+      initialized = true
+    }
+    return statsig.checkGateSync({ userID }, gateName)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    logger.forBot().error(`Failed to evaluate feature gate "${gateName}": ${message}`)
+    return false
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2252,6 +2252,9 @@ importers:
       preact-render-to-string:
         specifier: ^6.5.13
         version: 6.5.13(preact@10.26.6)
+      statsig-node:
+        specifier: ^6.5.1
+        version: 6.5.1
       whatsapp-api-js:
         specifier: 6.2.2-beta.0
         version: 6.2.2-beta.0
@@ -3035,7 +3038,7 @@ importers:
         version: 2.0.0
       '@bpinternal/zui':
         specifier: ^2.1.1
-        version: link:../zui
+        version: 2.3.0
       '@jitl/quickjs-singlefile-browser-release-sync':
         specifier: ^0.31.0
         version: 0.31.0
@@ -3135,7 +3138,7 @@ importers:
         version: link:../client
       '@bpinternal/zui':
         specifier: ^2.1.1
-        version: link:../zui
+        version: 2.3.0
       browser-or-node:
         specifier: ^2.1.1
         version: 2.1.1
@@ -3175,7 +3178,7 @@ importers:
         version: 1.0.2
       '@bpinternal/zui':
         specifier: ^2.1.1
-        version: link:../zui
+        version: 2.3.0
       json5:
         specifier: ^2.2.3
         version: 2.2.3
@@ -3221,7 +3224,7 @@ importers:
         version: 1.0.2
       '@bpinternal/zui':
         specifier: ^2.1.1
-        version: link:../zui
+        version: 2.3.0
       json5:
         specifier: ^2.2.3
         version: 2.2.3
@@ -4250,6 +4253,10 @@ packages:
 
   '@bpinternal/yargs-extra@0.0.3':
     resolution: {integrity: sha512-e/unlq0LX4CJUv1jGOv1UgwB/h2M0NCXnwD4lEw496GpkQikO668RS+BBlRhkqdGfZmvKDkXZZ96xJCn+i6Ymg==}
+
+  '@bpinternal/zui@2.3.0':
+    resolution: {integrity: sha512-U7LJnejsjB4tyzozP4ZuW2gs5CRqRtl4d1yAys56x0NDIlbxR5xF4lSSfSewLg9+gn0seyxDVRjZYrfMd2MbTg==}
+    engines: {node: '>=18.0.0'}
 
   '@colors/colors@1.6.0':
     resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
@@ -8987,6 +8994,9 @@ packages:
     resolution: {integrity: sha512-58yWmlHpp7VYfcdTwMTvwMmqx/Elfxjd9RXTDyMsbL7lLWmhMylLEqiYVLKuLzOZqVgiWXD9MfR62Vv89VRxkw==}
     engines: {node: '>=4'}
 
+  ip3country@5.0.0:
+    resolution: {integrity: sha512-lcFLMFU4eO1Z7tIpbVFZkaZ5ltqpeaRx7L9NsAbA9uA7/O/rj3RF8+evE5gDitooaTTIqjdzZrenFO/OOxQ2ew==}
+
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
@@ -11289,6 +11299,10 @@ packages:
   starkbank-ecdsa@1.1.5:
     resolution: {integrity: sha512-5O9CJ0QF6pTrtDg6dmaHy1GC/2wA1tcXsYanWOCzg+2cZrCDylEvEl6krzI4Zy8ryar00lHErRTT2Q61w/MUVA==}
 
+  statsig-node@6.5.1:
+    resolution: {integrity: sha512-/rKvMMN9SWTK8+b7MyRP1wOsStsKf55Mdj8O2ffV/bCQ/38bXYCC/GVd3gVvBSwVCibAnkTz2v1gpRJSIKsBIg==}
+    engines: {pnpm: never}
+
   statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
@@ -11795,6 +11809,10 @@ packages:
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
     engines: {node: '>=14.17'}
+    hasBin: true
+
+  ua-parser-js@1.0.41:
+    resolution: {integrity: sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug==}
     hasBin: true
 
   uc.micro@2.1.0:
@@ -13816,6 +13834,8 @@ snapshots:
       lodash: 4.17.21
       yargs: 17.7.2
       yn: 4.0.0
+
+  '@bpinternal/zui@2.3.0': {}
 
   '@colors/colors@1.6.0': {}
 
@@ -19425,6 +19445,8 @@ snapshots:
 
   ip-regex@2.1.0: {}
 
+  ip3country@5.0.0: {}
+
   ipaddr.js@1.9.1: {}
 
   is-alphabetical@1.0.4: {}
@@ -22281,6 +22303,15 @@ snapshots:
       big-integer: 1.6.52
       js-sha256: 0.9.0
 
+  statsig-node@6.5.1:
+    dependencies:
+      ip3country: 5.0.0
+      node-fetch: 2.7.0
+      ua-parser-js: 1.0.41
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - encoding
+
   statuses@2.0.1: {}
 
   statuses@2.0.2: {}
@@ -22869,6 +22900,8 @@ snapshots:
   typescript@5.7.2: {}
 
   typescript@5.8.3: {}
+
+  ua-parser-js@1.0.41: {}
 
   uc.micro@2.1.0: {}
 


### PR DESCRIPTION
## O que

Introduz o **Statsig** na integração de WhatsApp (`@stay/whatsapp-stay`) e expõe um helper reutilizável de feature toggle para gatear dinamicamente — sem redeploy e com rollout gradual por telefone — o encaminhamento inbound ao Darwin no **modo sombra**.

- `package.json`: adiciona a dependência `statsig-node` (`^6.5.1`, mesma versão do Darwin).
- `integration.definition.ts`: declara o secret `STATSIG_API_KEY` (acessível em runtime via `bp.secrets.STATSIG_API_KEY`, mesmo padrão de `POSTHOG_KEY`).
- `src/misc/feature-toggle.ts`: helper `isInboundForwardingEnabled(phone, logger)` + constante do gate `INBOUND_FORWARDING_GATE` (`botpress-whatsapp-events-forwarding`, 35 chars).
- `src/misc/feature-toggle.test.ts`: testes (vitest) cobrindo os 4 cenários.

## Por quê

O encaminhamento inbound (FOU-541, ainda não implementado) é especificado como off-by-default apenas pela presença dos secrets `DARWIN_INBOUND_URL`/`DARWIN_API_KEY`. Para operar o modo sombra com segurança — kill-switch e rollout sem redeploy — precisamos de um gate dinâmico que **some-se (AND)** ao guard de secrets. O Darwin já usa `statsig-node` como referência de convenção (`StatsigFeatureToggleAppService`: init lazy idempotente + `checkGateSync` com try/catch fail-closed).

Decisões de design do helper:
- **Fail-closed**: sem `STATSIG_API_KEY` → retorna `false` sem chamar o Statsig.
- **Init lazy idempotente**: `statsig.initialize()` é aguardado antes do `checkGateSync`; a flag de módulo só é marcada após init bem-sucedido (não fica presa em `true` se o init falhar) e é reaproveitada em instâncias quentes.
- **Best-effort**: qualquer erro (init ou checkGate) é logado via `logger.forBot()` e retorna `false` — nunca derruba o hot path do bot.
- `userID` do `StatsigUser` é o **telefone** (não o bsuid), decisão desta task para o rollout gradual.

## Escopo

- ✅ Infra (secret + dependência) + helper reutilizável + testes.
- ❌ Fora de escopo: wiring/consumo do gate no `messagesHandler` e o POST de encaminhamento em si (**FOU-541**); a atualização do OpenSpec no repo darwin (PR separado, stay-technologies/darwin#8679).

## Como verificar

```bash
cd integrations/whatsapp && npx vitest --run src/misc/feature-toggle.test.ts
```

Relates to FOU-550