### PR TITLE
(FOU-541) Encaminhar mensagens inbound do WhatsApp ao Darwin

### DIFF
--- a/integrations/whatsapp/integration.definition.ts
+++ b/integrations/whatsapp/integration.definition.ts
@@ -720,6 +720,12 @@ export default new IntegrationDefinition({
     STATSIG_API_KEY: {
       description: 'Statsig server SDK key used to evaluate feature toggles (e.g. inbound forwarding to Darwin)',
     },
+    DARWIN_INBOUND_URL: {
+      description: 'Darwin inbound endpoint URL that receives forwarded WhatsApp messages',
+    },
+    DARWIN_API_KEY: {
+      description: 'Shared API key sent as the X-API-KEY header when forwarding inbound messages to Darwin',
+    },
   },
   entities: {
     proactiveConversation: {

--- a/integrations/whatsapp/src/misc/darwin-inbound-forwarding.test.ts
+++ b/integrations/whatsapp/src/misc/darwin-inbound-forwarding.test.ts
@@ -1,0 +1,347 @@
+import axios from 'axios'
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+import { buildInboundEnvelope, forwardInboundMessage } from './darwin-inbound-forwarding'
+import { WhatsAppMessageValue } from './types'
+
+vi.mock('axios', () => ({
+  default: {
+    post: vi.fn(),
+  },
+}))
+
+const isInboundForwardingEnabled = vi.fn()
+vi.mock('./feature-toggle', () => ({
+  isInboundForwardingEnabled: (...args: unknown[]) => isInboundForwardingEnabled(...args),
+}))
+
+const mockedAxiosPost = vi.mocked(axios.post)
+
+const URL = 'https://darwin.example.com/inbound'
+const API_KEY = 'secret-api-key'
+const PHONE = '5511999999999'
+const BSUID = 'bsuid-123'
+const NAME = 'Alice'
+// 2021-01-01T00:00:00.000Z
+const TIMESTAMP = '1609459200'
+
+function buildLogger() {
+  const error = vi.fn()
+  const logger = { forBot: () => ({ error }) }
+  return { logger, error }
+}
+
+function buildValue(): WhatsAppMessageValue {
+  return {
+    messaging_product: 'whatsapp',
+    metadata: {
+      display_phone_number: '15550001111',
+      phone_number_id: 'phone-number-id-1',
+    },
+  } as WhatsAppMessageValue
+}
+
+type AnyMessage = NonNullable<WhatsAppMessageValue['messages']>[number]
+type AnyContact = NonNullable<WhatsAppMessageValue['contacts']>[number]
+
+function buildTextMessage(overrides: Partial<Record<string, unknown>> = {}): AnyMessage {
+  return {
+    from: PHONE,
+    id: 'wamid.TEXT',
+    timestamp: TIMESTAMP,
+    type: 'text',
+    text: { body: 'hello world' },
+    ...overrides,
+  } as AnyMessage
+}
+
+function buildImageMessage(): AnyMessage {
+  return {
+    from: PHONE,
+    id: 'wamid.IMAGE',
+    timestamp: TIMESTAMP,
+    type: 'image',
+    image: { id: 'media-1', sha256: 'abc', mime_type: 'image/jpeg', caption: 'a pic' },
+  } as AnyMessage
+}
+
+function buildContact(overrides: Partial<AnyContact> = {}): AnyContact {
+  return {
+    wa_id: PHONE,
+    user_id: BSUID,
+    profile: { name: NAME },
+    ...overrides,
+  } as AnyContact
+}
+
+describe('buildInboundEnvelope', () => {
+  test('builds the exact contract shape for a text message', () => {
+    const { logger } = buildLogger()
+    const message = buildTextMessage({ context: { id: 'wamid.REPLIED' } })
+
+    const envelope = buildInboundEnvelope(message, buildValue(), buildContact(), logger as never)
+
+    expect(envelope).toEqual({
+      source: 'whatsapp',
+      bot: {
+        phoneNumberId: 'phone-number-id-1',
+        displayPhoneNumber: '15550001111',
+      },
+      events: [
+        {
+          wamid: 'wamid.TEXT',
+          occurredAt: '2021-01-01T00:00:00.000Z',
+          type: 'text',
+          content: { body: 'hello world' },
+          text: 'hello world',
+          sender: {
+            phone: PHONE,
+            bsuid: BSUID,
+            name: NAME,
+          },
+          replyToWamid: 'wamid.REPLIED',
+        },
+      ],
+    })
+  })
+
+  test('text message: text = message.text.body and content = raw text sub-object', () => {
+    const { logger } = buildLogger()
+    const envelope = buildInboundEnvelope(buildTextMessage(), buildValue(), buildContact(), logger as never)
+
+    expect(envelope.events[0]!.text).toBe('hello world')
+    expect(envelope.events[0]!.content).toEqual({ body: 'hello world' })
+  })
+
+  test('non-text message: text is absent and content = raw per-type sub-object', () => {
+    const { logger } = buildLogger()
+    const message = buildImageMessage()
+
+    const envelope = buildInboundEnvelope(message, buildValue(), buildContact(), logger as never)
+
+    expect(envelope.events[0]!.type).toBe('image')
+    expect('text' in envelope.events[0]!).toBe(false)
+    expect(envelope.events[0]!.content).toEqual({
+      id: 'media-1',
+      sha256: 'abc',
+      mime_type: 'image/jpeg',
+      caption: 'a pic',
+    })
+  })
+
+  test('sender.name comes from contact.profile?.name; null when absent', () => {
+    const { logger } = buildLogger()
+
+    const withName = buildInboundEnvelope(buildTextMessage(), buildValue(), buildContact(), logger as never)
+    expect(withName.events[0]!.sender.name).toBe(NAME)
+
+    const noProfile = buildInboundEnvelope(
+      buildTextMessage(),
+      buildValue(),
+      buildContact({ profile: undefined }),
+      logger as never
+    )
+    expect(noProfile.events[0]!.sender.name).toBeNull()
+  })
+
+  test('phone and bsuid are null when absent on the contact', () => {
+    const { logger } = buildLogger()
+
+    const envelope = buildInboundEnvelope(
+      buildTextMessage(),
+      buildValue(),
+      buildContact({ wa_id: undefined, user_id: undefined }),
+      logger as never
+    )
+
+    expect(envelope.events[0]!.sender.phone).toBeNull()
+    expect(envelope.events[0]!.sender.bsuid).toBeNull()
+  })
+
+  test('replyToWamid is the raw Meta wamid from message.context?.id; null when absent', () => {
+    const { logger } = buildLogger()
+
+    const noContext = buildInboundEnvelope(buildTextMessage(), buildValue(), buildContact(), logger as never)
+    expect(noContext.events[0]!.replyToWamid).toBeNull()
+
+    const withContext = buildInboundEnvelope(
+      buildTextMessage({ context: { id: 'wamid.META' } }),
+      buildValue(),
+      buildContact(),
+      logger as never
+    )
+    expect(withContext.events[0]!.replyToWamid).toBe('wamid.META')
+  })
+
+  test('occurredAt is ISO-8601 UTC derived from the epoch-seconds string', () => {
+    const { logger } = buildLogger()
+    const message = buildTextMessage({ timestamp: '1700000000' })
+
+    const envelope = buildInboundEnvelope(message, buildValue(), buildContact(), logger as never)
+
+    expect(envelope.events[0]!.occurredAt).toBe(new Date(1700000000 * 1000).toISOString())
+  })
+
+  test('invalid timestamp: logs a fallback and still produces an envelope', () => {
+    const { logger, error } = buildLogger()
+    const message = buildTextMessage({ timestamp: 'not-a-number' })
+
+    const envelope = buildInboundEnvelope(message, buildValue(), buildContact(), logger as never)
+
+    expect(error).toHaveBeenCalledTimes(1)
+    // A valid ISO-8601 string was still produced (fallback to current time)
+    expect(() => new Date(envelope.events[0]!.occurredAt).toISOString()).not.toThrow()
+    expect(Number.isNaN(Date.parse(envelope.events[0]!.occurredAt))).toBe(false)
+  })
+})
+
+describe('forwardInboundMessage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    isInboundForwardingEnabled.mockResolvedValue(true)
+    mockedAxiosPost.mockResolvedValue({ status: 200 } as never)
+  })
+
+  test('secrets present + gate ON: POSTs once with exact url, envelope, headers and timeout', async () => {
+    const { logger } = buildLogger()
+    const message = buildTextMessage({ context: { id: 'wamid.REPLIED' } })
+    const value = buildValue()
+    const contact = buildContact()
+
+    await forwardInboundMessage({
+      url: URL,
+      apiKey: API_KEY,
+      phone: PHONE,
+      message,
+      value,
+      contact,
+      logger: logger as never,
+    })
+
+    expect(mockedAxiosPost).toHaveBeenCalledTimes(1)
+    expect(mockedAxiosPost).toHaveBeenCalledWith(
+      URL,
+      buildInboundEnvelope(message, value, contact, logger as never),
+      {
+        headers: {
+          'X-API-KEY': API_KEY,
+          'Content-Type': 'application/json',
+        },
+        timeout: 3000,
+      }
+    )
+  })
+
+  test('DARWIN_INBOUND_URL missing: no POST and gate is not consulted', async () => {
+    const { logger } = buildLogger()
+
+    await forwardInboundMessage({
+      url: undefined,
+      apiKey: API_KEY,
+      phone: PHONE,
+      message: buildTextMessage(),
+      value: buildValue(),
+      contact: buildContact(),
+      logger: logger as never,
+    })
+
+    expect(mockedAxiosPost).not.toHaveBeenCalled()
+    expect(isInboundForwardingEnabled).not.toHaveBeenCalled()
+  })
+
+  test('DARWIN_INBOUND_URL empty string: no POST and gate is not consulted', async () => {
+    const { logger } = buildLogger()
+
+    await forwardInboundMessage({
+      url: '',
+      apiKey: API_KEY,
+      phone: PHONE,
+      message: buildTextMessage(),
+      value: buildValue(),
+      contact: buildContact(),
+      logger: logger as never,
+    })
+
+    expect(mockedAxiosPost).not.toHaveBeenCalled()
+    expect(isInboundForwardingEnabled).not.toHaveBeenCalled()
+  })
+
+  test('DARWIN_API_KEY missing: no POST and gate is not consulted', async () => {
+    const { logger } = buildLogger()
+
+    await forwardInboundMessage({
+      url: URL,
+      apiKey: undefined,
+      phone: PHONE,
+      message: buildTextMessage(),
+      value: buildValue(),
+      contact: buildContact(),
+      logger: logger as never,
+    })
+
+    expect(mockedAxiosPost).not.toHaveBeenCalled()
+    expect(isInboundForwardingEnabled).not.toHaveBeenCalled()
+  })
+
+  test('secrets present but gate OFF: no POST', async () => {
+    const { logger } = buildLogger()
+    isInboundForwardingEnabled.mockResolvedValue(false)
+
+    await forwardInboundMessage({
+      url: URL,
+      apiKey: API_KEY,
+      phone: PHONE,
+      message: buildTextMessage(),
+      value: buildValue(),
+      contact: buildContact(),
+      logger: logger as never,
+    })
+
+    expect(isInboundForwardingEnabled).toHaveBeenCalledWith(PHONE, logger)
+    expect(mockedAxiosPost).not.toHaveBeenCalled()
+  })
+
+  test('axios.post rejects: does not throw and logs the error once', async () => {
+    const { logger, error } = buildLogger()
+    mockedAxiosPost.mockRejectedValue(new Error('network down'))
+
+    await expect(
+      forwardInboundMessage({
+        url: URL,
+        apiKey: API_KEY,
+        phone: PHONE,
+        message: buildTextMessage(),
+        value: buildValue(),
+        contact: buildContact(),
+        logger: logger as never,
+      })
+    ).resolves.toBeUndefined()
+
+    expect(error).toHaveBeenCalledTimes(1)
+  })
+
+  test('called once per message yields one POST per call (fan-out at the loop level)', async () => {
+    const { logger } = buildLogger()
+    const value = buildValue()
+
+    await forwardInboundMessage({
+      url: URL,
+      apiKey: API_KEY,
+      phone: PHONE,
+      message: buildTextMessage({ id: 'wamid.A' }),
+      value,
+      contact: buildContact(),
+      logger: logger as never,
+    })
+    await forwardInboundMessage({
+      url: URL,
+      apiKey: API_KEY,
+      phone: PHONE,
+      message: buildImageMessage(),
+      value,
+      contact: buildContact(),
+      logger: logger as never,
+    })
+
+    expect(mockedAxiosPost).toHaveBeenCalledTimes(2)
+  })
+})

--- a/integrations/whatsapp/src/misc/darwin-inbound-forwarding.test.ts
+++ b/integrations/whatsapp/src/misc/darwin-inbound-forwarding.test.ts
@@ -192,6 +192,29 @@ describe('buildInboundEnvelope', () => {
     expect(() => new Date(envelope.events[0]!.occurredAt).toISOString()).not.toThrow()
     expect(Number.isNaN(Date.parse(envelope.events[0]!.occurredAt))).toBe(false)
   })
+
+  test('empty/whitespace timestamp: treated as invalid (fallback to now), not epoch 0 / 1970', () => {
+    const { logger, error } = buildLogger()
+    const before = Date.now()
+    const message = buildTextMessage({ timestamp: '   ' })
+
+    const envelope = buildInboundEnvelope(message, buildValue(), buildContact(), logger as never)
+    const after = Date.now()
+
+    expect(error).toHaveBeenCalledTimes(1)
+    const occurredAtMs = Date.parse(envelope.events[0]!.occurredAt)
+    // Fallback is current time, NOT 1970 (which is what Number('   ') === 0 would produce)
+    expect(occurredAtMs).toBeGreaterThanOrEqual(before)
+    expect(occurredAtMs).toBeLessThanOrEqual(after)
+  })
+
+  test('contact is undefined: sender phone/bsuid/name all null, no throw', () => {
+    const { logger } = buildLogger()
+
+    const envelope = buildInboundEnvelope(buildTextMessage(), buildValue(), undefined, logger as never)
+
+    expect(envelope.events[0]!.sender).toEqual({ phone: null, bsuid: null, name: null })
+  })
 })
 
 describe('forwardInboundMessage', () => {
@@ -254,6 +277,23 @@ describe('forwardInboundMessage', () => {
     await forwardInboundMessage({
       url: '',
       apiKey: API_KEY,
+      phone: PHONE,
+      message: buildTextMessage(),
+      value: buildValue(),
+      contact: buildContact(),
+      logger: logger as never,
+    })
+
+    expect(mockedAxiosPost).not.toHaveBeenCalled()
+    expect(isInboundForwardingEnabled).not.toHaveBeenCalled()
+  })
+
+  test('DARWIN_API_KEY empty string: no POST and gate is not consulted', async () => {
+    const { logger } = buildLogger()
+
+    await forwardInboundMessage({
+      url: URL,
+      apiKey: '',
       phone: PHONE,
       message: buildTextMessage(),
       value: buildValue(),

--- a/integrations/whatsapp/src/misc/darwin-inbound-forwarding.ts
+++ b/integrations/whatsapp/src/misc/darwin-inbound-forwarding.ts
@@ -1,0 +1,128 @@
+import axios from 'axios'
+import { extractContactIdentifiers } from './bsuid-extraction'
+import { isInboundForwardingEnabled } from './feature-toggle'
+import { WhatsAppMessageValue } from './types'
+import * as bp from '.botpress'
+
+type InboundMessage = NonNullable<WhatsAppMessageValue['messages']>[number]
+type InboundContact = NonNullable<WhatsAppMessageValue['contacts']>[number]
+
+export type InboundEnvelope = {
+  source: 'whatsapp'
+  bot: {
+    phoneNumberId: string
+    displayPhoneNumber: string
+  }
+  events: Array<{
+    wamid: string
+    occurredAt: string
+    type: string
+    content: unknown
+    text?: string
+    sender: {
+      phone: string | null
+      bsuid: string | null
+      name: string | null
+    }
+    replyToWamid: string | null
+  }>
+}
+
+const POST_TIMEOUT_MS = 3000
+
+/**
+ * Converts a WhatsApp epoch-seconds timestamp string into an ISO-8601 UTC string.
+ * Falls back to the current time (logged) when the timestamp is not a valid number,
+ * so forwarding stays best-effort and never crashes the hot path.
+ */
+function toIsoOccurredAt(timestamp: string, logger: bp.Logger): string {
+  const epochSeconds = Number(timestamp)
+  if (Number.isNaN(epochSeconds)) {
+    logger
+      .forBot()
+      .error(`Invalid WhatsApp message timestamp "${timestamp}" while forwarding to Darwin, using current time`)
+    return new Date().toISOString()
+  }
+  return new Date(epochSeconds * 1000).toISOString()
+}
+
+/**
+ * Pure builder: turns a single inbound WhatsApp message into the Darwin inbound contract envelope.
+ * Media is NOT downloaded — `content` is the raw per-type sub-object exactly as received from Meta.
+ */
+export function buildInboundEnvelope(
+  message: InboundMessage,
+  value: WhatsAppMessageValue,
+  contact: InboundContact | undefined,
+  logger: bp.Logger
+): InboundEnvelope {
+  const { bsuid, phone } = contact ? extractContactIdentifiers(contact) : { bsuid: undefined, phone: undefined }
+
+  const content = (message as Record<string, unknown>)[message.type]
+  const text = message.type === 'text' ? message.text.body : undefined
+
+  return {
+    source: 'whatsapp',
+    bot: {
+      phoneNumberId: value.metadata.phone_number_id,
+      displayPhoneNumber: value.metadata.display_phone_number,
+    },
+    events: [
+      {
+        wamid: message.id,
+        occurredAt: toIsoOccurredAt(message.timestamp, logger),
+        type: message.type,
+        content,
+        ...(text !== undefined && { text }),
+        sender: {
+          phone: phone ?? null,
+          bsuid: bsuid ?? null,
+          name: contact?.profile?.name ?? null,
+        },
+        replyToWamid: message.context?.id ?? null,
+      },
+    ],
+  }
+}
+
+export type ForwardInboundMessageParams = {
+  url: string | undefined
+  apiKey: string | undefined
+  phone: string
+  message: InboundMessage
+  value: WhatsAppMessageValue
+  contact: InboundContact | undefined
+  logger: bp.Logger
+}
+
+/**
+ * Best-effort forwarder. Gated by (both secrets present) AND (Statsig gate on).
+ * Any failure is logged and swallowed — it must never break the bot's hot path.
+ */
+export async function forwardInboundMessage(params: ForwardInboundMessageParams): Promise<void> {
+  const { url, apiKey, phone, message, value, contact, logger } = params
+
+  // Off-by-default case: missing secrets is normal, do not emit noisy per-message warnings
+  // and do not even consult the gate.
+  if (!url || !apiKey) {
+    return
+  }
+
+  if (!(await isInboundForwardingEnabled(phone, logger))) {
+    return
+  }
+
+  try {
+    const envelope = buildInboundEnvelope(message, value, contact, logger)
+    await axios.post(url, envelope, {
+      headers: {
+        'X-API-KEY': apiKey,
+        'Content-Type': 'application/json',
+      },
+      timeout: POST_TIMEOUT_MS,
+    })
+  } catch (thrown: unknown) {
+    const errMsg = thrown instanceof Error ? thrown.message : 'Unknown error thrown'
+    logger.forBot().error(`Failed to forward inbound WhatsApp message to Darwin: ${errMsg}`)
+  }
+}

--- a/integrations/whatsapp/src/misc/darwin-inbound-forwarding.ts
+++ b/integrations/whatsapp/src/misc/darwin-inbound-forwarding.ts
@@ -37,7 +37,7 @@ const POST_TIMEOUT_MS = 3000
  */
 function toIsoOccurredAt(timestamp: string, logger: bp.Logger): string {
   const epochSeconds = Number(timestamp)
-  if (Number.isNaN(epochSeconds)) {
+  if (timestamp.trim() === '' || !Number.isFinite(epochSeconds)) {
     logger
       .forBot()
       .error(`Invalid WhatsApp message timestamp "${timestamp}" while forwarding to Darwin, using current time`)

--- a/integrations/whatsapp/src/webhook/handlers/messages.ts
+++ b/integrations/whatsapp/src/webhook/handlers/messages.ts
@@ -5,6 +5,7 @@ import axios from 'axios'
 import { INTEGRATION_NAME, INTEGRATION_VERSION } from 'integration.definition'
 import { getAccessToken, getAuthenticatedWhatsappClient } from '../../auth'
 import { extractContactIdentifiers } from '../../misc/bsuid-extraction'
+import { forwardInboundMessage } from '../../misc/darwin-inbound-forwarding'
 import { buildConversationTags } from '../../misc/identifier-decision'
 import { safeFormatPhoneNumber } from '../../misc/phone-number-to-whatsapp'
 import { WhatsAppMessage, WhatsAppMessageValue } from '../../misc/types'
@@ -129,6 +130,18 @@ export const messagesHandler = async (
       ...(replyTo && { replyTo }),
       ..._processReferralTags(message, logger),
     },
+  })
+
+  // Best-effort: forward the inbound message to Darwin AFTER bot processing so it never
+  // adds latency or risk before delivery. Gated by secrets + Statsig; failures are swallowed.
+  await forwardInboundMessage({
+    url: bp.secrets.DARWIN_INBOUND_URL,
+    apiKey: bp.secrets.DARWIN_API_KEY,
+    phone: phone ?? '',
+    message,
+    value,
+    contact,
+    logger,
   })
 }
 


### PR DESCRIPTION
A Espiral 1 do tracer inbound (FOU-529) coloca o WhatsApp em modo sombra: o Darwin precisa observar cada mensagem recebida para persisti-la e reconstruir o historico por contato, sem que o usuario perceba qualquer mudanca. Para isso, o fork da integracao passa a espelhar ao Darwin cada mensagem que chega, logo apos o processamento normal do bot.

O encaminhamento e deliberadamente best-effort e desligavel: por ser modo sombra, nenhuma falha de rede, timeout ou indisponibilidade do Darwin pode interromper o atendimento. Por isso ele so dispara quando a URL e a chave do Darwin estao configuradas E o feature toggle do Statsig esta ligado — a soma (AND) da um kill-switch e rollout gradual por telefone sem redeploy, reusando o helper entregue na FOU-550. Qualquer erro e apenas logado e o bot segue normalmente.

Nesta espiral apenas mensagens recebidas sao encaminhadas; status e echoes ficam de fora por construcao, ja que o encaminhamento vive somente no handler de mensagens.

Resolves FOU-541