### PR TITLE
chore(whatsapp-stay): bump integration to 1.4.1 (FOU-543)

### DIFF
--- a/integrations/whatsapp/integration.definition.ts
+++ b/integrations/whatsapp/integration.definition.ts
@@ -164,7 +164,7 @@ const defaultBotPhoneNumberId = {
 }
 
 export const INTEGRATION_NAME = 'whatsapp-stay'
-export const INTEGRATION_VERSION = '1.3.1'
+export const INTEGRATION_VERSION = '1.4.1'
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
   version: INTEGRATION_VERSION,


### PR DESCRIPTION
## O que

Bump da integração `whatsapp-stay` para a versão **1.4.1**, publicada no workspace de produção do Botpress Cloud.

## Por quê

O encaminhamento de mensagens inbound para o Darwin (FOU-541) e o feature toggle via Statsig (FOU-550) já estão em `master`, mas a versão da integração não havia sido bumpada — então o código não estava deployável como uma versão nova.

Um deploy intermediário (`1.4.0`) foi publicado com um `DARWIN_API_KEY` incorreto (resultando em `401` no endpoint do Darwin). A `1.4.1` corrige o secret e é a versão atualmente em produção.

## Mudança

- `integration.definition.ts`: `INTEGRATION_VERSION` `1.3.1` → `1.4.1`.

## Deploy / Ops (FOU-543)

- [x] `bp deploy` da `1.4.1` em produção (secret `DARWIN_API_KEY` corrigido).
- [ ] Upgrade do bot `1.4.0 → 1.4.1` no Studio.
- [ ] Validação E2E: mensagem inbound → `200` no Darwin → persistência por `wamid`.

Tag: `whatsapp-stay-1.4.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)