### PR TITLE
feat(whatsapp): forward outbound messages and delivery status to Darwin (FOU-530)

### DIFF
--- a/integrations/whatsapp/src/misc/darwin-inbound-forwarding.test.ts
+++ b/integrations/whatsapp/src/misc/darwin-inbound-forwarding.test.ts
@@ -142,6 +142,7 @@ describe('buildInboundEnvelope', () => {
           wamid: 'wamid.TEXT',
           occurredAt: '2021-01-01T00:00:00.000Z',
           type: 'text',
+          direction: 'INBOUND',
           content: { body: 'hello world' },
           text: 'hello world',
           sender: {

--- a/integrations/whatsapp/src/misc/darwin-inbound-forwarding.test.ts
+++ b/integrations/whatsapp/src/misc/darwin-inbound-forwarding.test.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import { describe, test, expect, beforeEach, vi } from 'vitest'
-import { buildInboundEnvelope, forwardInboundMessage } from './darwin-inbound-forwarding'
-import { WhatsAppMessageValue } from './types'
+import { buildInboundEnvelope, buildOutboundEnvelope, buildStatusEnvelope, forwardInboundMessage } from './darwin-inbound-forwarding'
+import { WhatsAppEchoMessage, WhatsAppMessageEchoValue, WhatsAppMessageValue, WhatsAppStatusValue } from './types'
 
 vi.mock('axios', () => ({
   default: {
@@ -71,6 +71,57 @@ function buildContact(overrides: Partial<AnyContact> = {}): AnyContact {
     profile: { name: NAME },
     ...overrides,
   } as AnyContact
+}
+
+function buildEchoValue(): WhatsAppMessageEchoValue {
+  return {
+    messaging_product: 'whatsapp',
+    metadata: {
+      display_phone_number: '15550001111',
+      phone_number_id: 'phone-number-id-1',
+    },
+    message_echoes: [],
+  } as WhatsAppMessageEchoValue
+}
+
+function buildTextEcho(overrides: Partial<Record<string, unknown>> = {}): WhatsAppEchoMessage {
+  return {
+    from: '15550001111',
+    to: PHONE,
+    id: 'wamid.ECHO_TEXT',
+    timestamp: TIMESTAMP,
+    type: 'text',
+    text: { body: 'hello back' },
+    message_creation_type: 'agent',
+    ...overrides,
+  } as WhatsAppEchoMessage
+}
+
+function buildImageEcho(): WhatsAppEchoMessage {
+  return {
+    from: '15550001111',
+    to: PHONE,
+    id: 'wamid.ECHO_IMAGE',
+    timestamp: TIMESTAMP,
+    type: 'image',
+    image: { id: 'media-1', sha256: 'abc', mime_type: 'image/jpeg', caption: 'a pic' },
+    message_creation_type: 'agent',
+  } as WhatsAppEchoMessage
+}
+
+function buildStatus(overrides: Partial<WhatsAppStatusValue> = {}): WhatsAppStatusValue {
+  return {
+    id: 'wamid.STATUS',
+    status: 'delivered',
+    timestamp: TIMESTAMP,
+    recipient_id: PHONE,
+    ...overrides,
+  } as WhatsAppStatusValue
+}
+
+const METADATA = {
+  display_phone_number: '15550001111',
+  phone_number_id: 'phone-number-id-1',
 }
 
 describe('buildInboundEnvelope', () => {
@@ -214,6 +265,154 @@ describe('buildInboundEnvelope', () => {
     const envelope = buildInboundEnvelope(buildTextMessage(), buildValue(), undefined, logger as never)
 
     expect(envelope.events[0]!.sender).toEqual({ phone: null, bsuid: null, name: null })
+  })
+})
+
+describe('buildOutboundEnvelope', () => {
+  test('builds the exact contract shape for a text echo with direction OUTBOUND', () => {
+    const { logger } = buildLogger()
+    const echo = buildTextEcho({ context: { id: 'wamid.REPLIED' } })
+
+    const envelope = buildOutboundEnvelope(echo, buildEchoValue(), logger as never)
+
+    expect(envelope).toEqual({
+      source: 'whatsapp',
+      bot: {
+        phoneNumberId: 'phone-number-id-1',
+        displayPhoneNumber: '15550001111',
+      },
+      events: [
+        {
+          wamid: 'wamid.ECHO_TEXT',
+          occurredAt: '2021-01-01T00:00:00.000Z',
+          type: 'text',
+          direction: 'OUTBOUND',
+          content: { body: 'hello back' },
+          text: 'hello back',
+          sender: {
+            phone: PHONE,
+            bsuid: null,
+            name: null,
+          },
+          replyToWamid: 'wamid.REPLIED',
+        },
+      ],
+    })
+  })
+
+  test('direction is OUTBOUND and sender.phone = echo.to (recipient), bsuid/name null', () => {
+    const { logger } = buildLogger()
+
+    const envelope = buildOutboundEnvelope(buildTextEcho(), buildEchoValue(), logger as never)
+
+    expect(envelope.events[0]!.direction).toBe('OUTBOUND')
+    expect(envelope.events[0]!.sender).toEqual({ phone: PHONE, bsuid: null, name: null })
+  })
+
+  test('text echo: text = echo.text.body and content = raw text sub-object', () => {
+    const { logger } = buildLogger()
+
+    const envelope = buildOutboundEnvelope(buildTextEcho(), buildEchoValue(), logger as never)
+
+    expect(envelope.events[0]!.text).toBe('hello back')
+    expect(envelope.events[0]!.content).toEqual({ body: 'hello back' })
+  })
+
+  test('non-text echo: text is absent and content = raw per-type sub-object', () => {
+    const { logger } = buildLogger()
+
+    const envelope = buildOutboundEnvelope(buildImageEcho(), buildEchoValue(), logger as never)
+
+    expect(envelope.events[0]!.type).toBe('image')
+    expect('text' in envelope.events[0]!).toBe(false)
+    expect(envelope.events[0]!.content).toEqual({
+      id: 'media-1',
+      sha256: 'abc',
+      mime_type: 'image/jpeg',
+      caption: 'a pic',
+    })
+  })
+
+  test('replyToWamid is echo.context?.id; null when absent', () => {
+    const { logger } = buildLogger()
+
+    const noContext = buildOutboundEnvelope(buildTextEcho(), buildEchoValue(), logger as never)
+    expect(noContext.events[0]!.replyToWamid).toBeNull()
+
+    const withContext = buildOutboundEnvelope(
+      buildTextEcho({ context: { id: 'wamid.META' } }),
+      buildEchoValue(),
+      logger as never
+    )
+    expect(withContext.events[0]!.replyToWamid).toBe('wamid.META')
+  })
+
+  test('occurredAt is ISO-8601 UTC derived from the epoch-seconds string', () => {
+    const { logger } = buildLogger()
+    const echo = buildTextEcho({ timestamp: '1700000000' })
+
+    const envelope = buildOutboundEnvelope(echo, buildEchoValue(), logger as never)
+
+    expect(envelope.events[0]!.occurredAt).toBe(new Date(1700000000 * 1000).toISOString())
+  })
+
+  test('bot is taken from the echo value metadata', () => {
+    const { logger } = buildLogger()
+
+    const envelope = buildOutboundEnvelope(buildTextEcho(), buildEchoValue(), logger as never)
+
+    expect(envelope.bot).toEqual({ phoneNumberId: 'phone-number-id-1', displayPhoneNumber: '15550001111' })
+  })
+})
+
+describe('buildStatusEnvelope', () => {
+  test('builds the exact contract shape for a delivery status', () => {
+    const { logger } = buildLogger()
+
+    const envelope = buildStatusEnvelope(buildStatus(), METADATA, logger as never)
+
+    expect(envelope).toEqual({
+      source: 'whatsapp',
+      bot: {
+        phoneNumberId: 'phone-number-id-1',
+        displayPhoneNumber: '15550001111',
+      },
+      events: [
+        {
+          kind: 'status',
+          wamid: 'wamid.STATUS',
+          occurredAt: '2021-01-01T00:00:00.000Z',
+          status: 'delivered',
+        },
+      ],
+    })
+  })
+
+  test('event kind is "status" and carries wamid + status value', () => {
+    const { logger } = buildLogger()
+
+    const envelope = buildStatusEnvelope(buildStatus({ status: 'read', id: 'wamid.READ' }), METADATA, logger as never)
+
+    const event = envelope.events[0]!
+    expect('kind' in event && event.kind).toBe('status')
+    expect(event.wamid).toBe('wamid.READ')
+    expect('status' in event && event.status).toBe('read')
+  })
+
+  test('occurredAt is ISO-8601 UTC derived from the epoch-seconds string', () => {
+    const { logger } = buildLogger()
+
+    const envelope = buildStatusEnvelope(buildStatus({ timestamp: '1700000000' }), METADATA, logger as never)
+
+    expect(envelope.events[0]!.occurredAt).toBe(new Date(1700000000 * 1000).toISOString())
+  })
+
+  test('bot is taken from the provided metadata', () => {
+    const { logger } = buildLogger()
+
+    const envelope = buildStatusEnvelope(buildStatus(), METADATA, logger as never)
+
+    expect(envelope.bot).toEqual({ phoneNumberId: 'phone-number-id-1', displayPhoneNumber: '15550001111' })
   })
 })
 

--- a/integrations/whatsapp/src/misc/darwin-inbound-forwarding.ts
+++ b/integrations/whatsapp/src/misc/darwin-inbound-forwarding.ts
@@ -1,32 +1,47 @@
 import axios from 'axios'
 import { extractContactIdentifiers } from './bsuid-extraction'
 import { isInboundForwardingEnabled } from './feature-toggle'
-import { WhatsAppMessageValue } from './types'
+import { WhatsAppEchoMessage, WhatsAppMessageEchoValue, WhatsAppMessageValue, WhatsAppStatusValue } from './types'
 import * as bp from '.botpress'
 
 type InboundMessage = NonNullable<WhatsAppMessageValue['messages']>[number]
 type InboundContact = NonNullable<WhatsAppMessageValue['contacts']>[number]
 
-export type InboundEnvelope = {
-  source: 'whatsapp'
-  bot: {
-    phoneNumberId: string
-    displayPhoneNumber: string
-  }
-  events: Array<{
-    wamid: string
-    occurredAt: string
-    type: string
-    content: unknown
-    text?: string
-    sender: {
-      phone: string | null
-      bsuid: string | null
-      name: string | null
-    }
-    replyToWamid: string | null
-  }>
+type BotMetadata = {
+  phoneNumberId: string
+  displayPhoneNumber: string
 }
+
+type MessageEvent = {
+  wamid: string
+  occurredAt: string
+  type: string
+  direction?: 'INBOUND' | 'OUTBOUND'
+  content: unknown
+  text?: string
+  sender: {
+    phone: string | null
+    bsuid: string | null
+    name: string | null
+  }
+  replyToWamid: string | null
+}
+
+type StatusEvent = {
+  kind: 'status'
+  wamid: string
+  occurredAt: string
+  status: 'sent' | 'delivered' | 'read' | 'failed'
+}
+
+export type DarwinEnvelope = {
+  source: 'whatsapp'
+  bot: BotMetadata
+  events: Array<MessageEvent | StatusEvent>
+}
+
+// Kept as an alias for backwards compatibility with existing inbound call sites/tests.
+export type InboundEnvelope = DarwinEnvelope
 
 const POST_TIMEOUT_MS = 3000
 
@@ -47,6 +62,31 @@ function toIsoOccurredAt(timestamp: string, logger: bp.Logger): string {
 }
 
 /**
+ * Best-effort POST of a Darwin envelope. Any failure is logged (with the given label)
+ * and swallowed — it must never break the bot's hot path.
+ */
+async function postEnvelope(
+  url: string,
+  apiKey: string,
+  envelope: DarwinEnvelope,
+  logger: bp.Logger,
+  label: string
+): Promise<void> {
+  try {
+    await axios.post(url, envelope, {
+      headers: {
+        'X-API-KEY': apiKey,
+        'Content-Type': 'application/json',
+      },
+      timeout: POST_TIMEOUT_MS,
+    })
+  } catch (thrown: unknown) {
+    const errMsg = thrown instanceof Error ? thrown.message : 'Unknown error thrown'
+    logger.forBot().error(`Failed to forward ${label} to Darwin: ${errMsg}`)
+  }
+}
+
+/**
  * Pure builder: turns a single inbound WhatsApp message into the Darwin inbound contract envelope.
  * Media is NOT downloaded — `content` is the raw per-type sub-object exactly as received from Meta.
  */
@@ -55,7 +95,7 @@ export function buildInboundEnvelope(
   value: WhatsAppMessageValue,
   contact: InboundContact | undefined,
   logger: bp.Logger
-): InboundEnvelope {
+): DarwinEnvelope {
   const { bsuid, phone } = contact ? extractContactIdentifiers(contact) : { bsuid: undefined, phone: undefined }
 
   const content = (message as Record<string, unknown>)[message.type]
@@ -80,6 +120,69 @@ export function buildInboundEnvelope(
           name: contact?.profile?.name ?? null,
         },
         replyToWamid: message.context?.id ?? null,
+      },
+    ],
+  }
+}
+
+/**
+ * Pure builder: turns a single outbound WhatsApp echo into the Darwin contract envelope.
+ * `sender` carries the RECIPIENT for outbound (echoes carry no recipient bsuid).
+ * Media is NOT downloaded — `content` is the raw per-type sub-object exactly as received from Meta.
+ */
+export function buildOutboundEnvelope(
+  echo: WhatsAppEchoMessage,
+  value: WhatsAppMessageEchoValue,
+  logger: bp.Logger
+): DarwinEnvelope {
+  const content = (echo as Record<string, unknown>)[echo.type]
+  const text = echo.type === 'text' ? echo.text.body : undefined
+
+  return {
+    source: 'whatsapp',
+    bot: {
+      phoneNumberId: value.metadata.phone_number_id,
+      displayPhoneNumber: value.metadata.display_phone_number,
+    },
+    events: [
+      {
+        wamid: echo.id,
+        occurredAt: toIsoOccurredAt(echo.timestamp, logger),
+        type: echo.type,
+        direction: 'OUTBOUND',
+        content,
+        ...(text !== undefined && { text }),
+        sender: {
+          phone: echo.to ?? null,
+          bsuid: null,
+          name: null,
+        },
+        replyToWamid: echo.context?.id ?? null,
+      },
+    ],
+  }
+}
+
+/**
+ * Pure builder: turns a single WhatsApp delivery status into the Darwin contract envelope.
+ */
+export function buildStatusEnvelope(
+  status: WhatsAppStatusValue,
+  metadata: { phone_number_id: string; display_phone_number: string },
+  logger: bp.Logger
+): DarwinEnvelope {
+  return {
+    source: 'whatsapp',
+    bot: {
+      phoneNumberId: metadata.phone_number_id,
+      displayPhoneNumber: metadata.display_phone_number,
+    },
+    events: [
+      {
+        kind: 'status',
+        wamid: status.id,
+        occurredAt: toIsoOccurredAt(status.timestamp, logger),
+        status: status.status,
       },
     ],
   }
@@ -112,17 +215,60 @@ export async function forwardInboundMessage(params: ForwardInboundMessageParams)
     return
   }
 
-  try {
-    const envelope = buildInboundEnvelope(message, value, contact, logger)
-    await axios.post(url, envelope, {
-      headers: {
-        'X-API-KEY': apiKey,
-        'Content-Type': 'application/json',
-      },
-      timeout: POST_TIMEOUT_MS,
-    })
-  } catch (thrown: unknown) {
-    const errMsg = thrown instanceof Error ? thrown.message : 'Unknown error thrown'
-    logger.forBot().error(`Failed to forward inbound WhatsApp message to Darwin: ${errMsg}`)
+  const envelope = buildInboundEnvelope(message, value, contact, logger)
+  await postEnvelope(url, apiKey, envelope, logger, 'inbound WhatsApp message')
+}
+
+export type ForwardOutboundMessageParams = {
+  url: string | undefined
+  apiKey: string | undefined
+  phone: string
+  echo: WhatsAppEchoMessage
+  value: WhatsAppMessageEchoValue
+  logger: bp.Logger
+}
+
+/**
+ * Best-effort forwarder for outbound (echo) messages. Same gating as the inbound forwarder.
+ */
+export async function forwardOutboundMessage(params: ForwardOutboundMessageParams): Promise<void> {
+  const { url, apiKey, phone, echo, value, logger } = params
+
+  if (!url || !apiKey) {
+    return
   }
+
+  if (!(await isInboundForwardingEnabled(phone, logger))) {
+    return
+  }
+
+  const envelope = buildOutboundEnvelope(echo, value, logger)
+  await postEnvelope(url, apiKey, envelope, logger, 'outbound WhatsApp message')
+}
+
+export type ForwardStatusParams = {
+  url: string | undefined
+  apiKey: string | undefined
+  phone: string
+  status: WhatsAppStatusValue
+  metadata: { phone_number_id: string; display_phone_number: string }
+  logger: bp.Logger
+}
+
+/**
+ * Best-effort forwarder for delivery status events. Same gating as the inbound forwarder.
+ */
+export async function forwardStatus(params: ForwardStatusParams): Promise<void> {
+  const { url, apiKey, phone, status, metadata, logger } = params
+
+  if (!url || !apiKey) {
+    return
+  }
+
+  if (!(await isInboundForwardingEnabled(phone, logger))) {
+    return
+  }
+
+  const envelope = buildStatusEnvelope(status, metadata, logger)
+  await postEnvelope(url, apiKey, envelope, logger, 'WhatsApp delivery status')
 }

--- a/integrations/whatsapp/src/misc/darwin-inbound-forwarding.ts
+++ b/integrations/whatsapp/src/misc/darwin-inbound-forwarding.ts
@@ -112,6 +112,7 @@ export function buildInboundEnvelope(
         wamid: message.id,
         occurredAt: toIsoOccurredAt(message.timestamp, logger),
         type: message.type,
+        direction: 'INBOUND',
         content,
         ...(text !== undefined && { text }),
         sender: {

--- a/integrations/whatsapp/src/webhook/handler.ts
+++ b/integrations/whatsapp/src/webhook/handler.ts
@@ -77,7 +77,7 @@ const _handler: bp.IntegrationProps['handler'] = async (props: bp.HandlerProps) 
       }
       for (const status of changes.value.statuses ?? []) {
         try {
-          await statusHandler(status, props)
+          await statusHandler(status, changes.value, props)
         } catch (thrown: unknown) {
           const errMsg = thrown instanceof Error ? thrown.message : 'Unknown error thrown'
           logger.forBot().error(`Failed to process WhatsApp status event: ${errMsg}`)

--- a/integrations/whatsapp/src/webhook/handlers/echo.ts
+++ b/integrations/whatsapp/src/webhook/handlers/echo.ts
@@ -1,3 +1,4 @@
+import { forwardOutboundMessage } from '../../misc/darwin-inbound-forwarding'
 import { safeFormatPhoneNumber } from '../../misc/phone-number-to-whatsapp'
 import { WhatsAppMessageEchoValue, WhatsAppEchoMessage } from '../../misc/types'
 import { _handleMessage } from './messages'
@@ -66,4 +67,14 @@ export const echoHandler = async (
       payload: {},
     })
   }
+
+  // Best-effort forwarding to Darwin, AFTER bot processing — never throws into the hot path.
+  await forwardOutboundMessage({
+    url: bp.secrets.DARWIN_INBOUND_URL,
+    apiKey: bp.secrets.DARWIN_API_KEY,
+    phone: echo.to,
+    echo,
+    value,
+    logger,
+  })
 }

--- a/integrations/whatsapp/src/webhook/handlers/status.ts
+++ b/integrations/whatsapp/src/webhook/handlers/status.ts
@@ -1,7 +1,8 @@
 import { getAuthenticatedWhatsappClient } from 'src/auth'
 import { getMessageFromWhatsappMessageId } from 'src/misc/util'
 import { Text } from 'whatsapp-api-js/messages'
-import { WhatsAppStatusValue } from '../../misc/types'
+import { forwardStatus } from '../../misc/darwin-inbound-forwarding'
+import { WhatsAppMessageValue, WhatsAppStatusValue } from '../../misc/types'
 import * as bp from '.botpress'
 
 // Meta error codes for which a plain-text URL fallback is useful.
@@ -41,8 +42,24 @@ const _getMediaUrlFromPayload = (
   }
 }
 
-export const statusHandler = async (value: WhatsAppStatusValue, props: bp.HandlerProps) => {
+export const statusHandler = async (
+  value: WhatsAppStatusValue,
+  messageValue: WhatsAppMessageValue,
+  props: bp.HandlerProps
+) => {
   const { client, ctx, logger } = props
+
+  // Best-effort forwarding to Darwin runs regardless of whether Botpress has a
+  // local message for this wamid: Darwin correlates by its own wamid store and
+  // gracefully discards unknown ones, so it must not be gated by the lookup below.
+  await forwardStatus({
+    url: bp.secrets.DARWIN_INBOUND_URL,
+    apiKey: bp.secrets.DARWIN_API_KEY,
+    phone: value.recipient_id,
+    status: value,
+    metadata: messageValue.metadata,
+    logger,
+  })
 
   const message = await getMessageFromWhatsappMessageId(value.id, client)
   if (!message) {


### PR DESCRIPTION
## Por quê
A ingestão WhatsApp no Darwin (FOU-530) passou a ser **um endpoint único com uma união discriminada** de eventos `message` (com `direction`) e `status`. A integração já encaminhava só **inbound**; este PR completa o contrato encaminhando também **mensagens enviadas (outbound)** e **status de entrega**.

## O que muda (`integrations/whatsapp`)
- `src/misc/darwin-inbound-forwarding.ts`: envelope generalizado (`DarwinEnvelope` = `message | status`); helper `postEnvelope` (DRY); novos `buildOutboundEnvelope`/`forwardOutboundMessage` e `buildStatusEnvelope`/`forwardStatus`. Inbound inalterado (`InboundEnvelope` mantido como alias).
- `src/webhook/handlers/echo.ts`: encaminha a mensagem **enviada** (echo) com `direction: "OUTBOUND"` (best-effort, após o processamento do bot).
- `src/webhook/handlers/status.ts`: encaminha o **status de entrega** (`kind: "status"`, `status` ∈ sent/delivered/read/failed). Roda **independente** do lookup local do Botpress — o Darwin correlaciona por `wamid` e descarta desconhecidos.
- `src/webhook/handler.ts`: passa a metadata do bot (`changes.value`) ao `statusHandler` (necessária pro `bot.phoneNumberId` do envelope).
- Testes dos novos builders (`*.test.ts`).

## Contrato (bate com o Darwin)
- `POST <DARWIN_INBOUND_URL>` header `X-API-KEY`.
- Envelope: `{ source:"whatsapp", bot:{phoneNumberId, displayPhoneNumber}, events:[…] }`.
- `message`: `{ wamid, occurredAt(ISO), type, direction?("INBOUND"|"OUTBOUND"), content?, text?, sender:{phone,bsuid,name}, replyToWamid }`.
- `status`: `{ kind:"status", wamid, occurredAt(ISO), status }`.

## Notas
- **Best-effort / off-by-default**: só encaminha com `DARWIN_INBOUND_URL` + `DARWIN_API_KEY` presentes e o gate Statsig `botpress-whatsapp-events-forwarding` ligado; falhas são logadas e engolidas (nunca quebram o hot path).
- Sem segredo/config novos — reúsa os da Espiral 1.
- Não consegui rodar build/testes localmente (clone esparso, sem `node_modules`/`.botpress`) — validação no CI.

Relates to FOU-530
