### PR TITLE
chore(whatsapp-stay): bump integration version to 1.5.0 (FOU-530)

### DIFF
--- a/integrations/whatsapp/integration.definition.ts
+++ b/integrations/whatsapp/integration.definition.ts
@@ -164,7 +164,7 @@ const defaultBotPhoneNumberId = {
 }
 
 export const INTEGRATION_NAME = 'whatsapp-stay'
-export const INTEGRATION_VERSION = '1.4.1'
+export const INTEGRATION_VERSION = '1.5.0'
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
   version: INTEGRATION_VERSION,


### PR DESCRIPTION
## Summary

Bumps the `whatsapp-stay` integration version from `1.4.1` to `1.5.0`, covering the changes that landed after the 1.4.1 deploy:

- edb686a8 — feat(whatsapp): forward outbound messages and delivery status to Darwin (FOU-530)
- 398c2ad9 — refactor(whatsapp): set direction INBOUND explicitly in inbound envelope

## Deploy status

- ✅ `stay/whatsapp-stay v1.5.0` already deployed to the production workspace (2026-07-02).
- ✅ Tag [`whatsapp-stay-1.5.0`](https://github.com/stay-technologies/botpress/releases/tag/whatsapp-stay-1.5.0) points to the bump commit.
- All 14 workspace secrets unchanged (Darwin/Statsig secrets were already configured).
- Forwarding is gated behind the Statsig flag `botpress-whatsapp-events-forwarding` (fail-closed).

This PR only syncs `master` with the version that is live, avoiding a version conflict on the next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)