### PR TITLE
feat(whatsapp): forward bot-sent messages to Darwin at the send path (FOU-530)

### DIFF
--- a/integrations/whatsapp/integration.definition.ts
+++ b/integrations/whatsapp/integration.definition.ts
@@ -164,7 +164,7 @@ const defaultBotPhoneNumberId = {
 }
 
 export const INTEGRATION_NAME = 'whatsapp-stay'
-export const INTEGRATION_VERSION = '1.5.0'
+export const INTEGRATION_VERSION = '1.5.1'
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
   version: INTEGRATION_VERSION,

--- a/integrations/whatsapp/src/actions/start-conversation.ts
+++ b/integrations/whatsapp/src/actions/start-conversation.ts
@@ -4,6 +4,7 @@ import { Language, Template } from 'whatsapp-api-js/messages'
 import type { TemplateComponent } from 'whatsapp-api-js/types'
 import { getDefaultBotPhoneNumberId, getAuthenticatedWhatsappClient } from '../auth'
 import { forwardSentMessage } from '../misc/darwin-inbound-forwarding'
+import { getDarwinForwardingSecrets } from '../misc/darwin-forwarding-secrets'
 import { buildConversationTags, chooseSendRecipient } from '../misc/identifier-decision'
 import { safeFormatPhoneNumber } from '../misc/phone-number-to-whatsapp'
 import {
@@ -161,8 +162,7 @@ export const startConversation: bp.IntegrationProps['actions']['startConversatio
   if (whatsappMessageId) {
     // Best-effort forwarding to Darwin — never throws into the action path.
     await forwardSentMessage({
-      url: bp.secrets.DARWIN_INBOUND_URL,
-      apiKey: bp.secrets.DARWIN_API_KEY,
+      ...getDarwinForwardingSecrets(),
       wamid: whatsappMessageId,
       messageType: 'template',
       message: template,

--- a/integrations/whatsapp/src/actions/start-conversation.ts
+++ b/integrations/whatsapp/src/actions/start-conversation.ts
@@ -3,6 +3,7 @@ import { INTEGRATION_NAME, INTEGRATION_VERSION } from 'integration.definition'
 import { Language, Template } from 'whatsapp-api-js/messages'
 import type { TemplateComponent } from 'whatsapp-api-js/types'
 import { getDefaultBotPhoneNumberId, getAuthenticatedWhatsappClient } from '../auth'
+import { forwardSentMessage } from '../misc/darwin-inbound-forwarding'
 import { buildConversationTags, chooseSendRecipient } from '../misc/identifier-decision'
 import { safeFormatPhoneNumber } from '../misc/phone-number-to-whatsapp'
 import {
@@ -156,6 +157,21 @@ export const startConversation: bp.IntegrationProps['actions']['startConversatio
       const message = err instanceof Error ? err.message : ''
       logger.forBot().error(`Failed to Create synthetic message from template message - Error: ${message}`)
     })
+
+  if (whatsappMessageId) {
+    // Best-effort forwarding to Darwin — never throws into the action path.
+    await forwardSentMessage({
+      url: bp.secrets.DARWIN_INBOUND_URL,
+      apiKey: bp.secrets.DARWIN_API_KEY,
+      wamid: whatsappMessageId,
+      messageType: 'template',
+      message: template,
+      recipientPhone: formattedPhone,
+      recipientBsuid: userBsuid,
+      botPhoneNumberId,
+      logger,
+    })
+  }
 
   logger
     .forBot()

--- a/integrations/whatsapp/src/actions/start-flow.ts
+++ b/integrations/whatsapp/src/actions/start-flow.ts
@@ -2,6 +2,7 @@ import { RuntimeError, z } from '@botpress/sdk'
 import { getDefaultBotPhoneNumberId, getAuthenticatedWhatsappClient } from '../auth'
 import { Interactive, Body, ActionFlow } from 'whatsapp-api-js/messages'
 import { forwardSentMessage } from '../misc/darwin-inbound-forwarding'
+import { getDarwinForwardingSecrets } from '../misc/darwin-forwarding-secrets'
 import { buildConversationTags, chooseSendRecipient } from '../misc/identifier-decision'
 import * as bp from '.botpress'
 
@@ -118,11 +119,10 @@ export const startFlow = async ({ ctx, input, client, logger }: any) => {
   if (wamid) {
     // Best-effort forwarding to Darwin — never throws into the action path.
     await forwardSentMessage({
-      url: bp.secrets.DARWIN_INBOUND_URL,
-      apiKey: bp.secrets.DARWIN_API_KEY,
+      ...getDarwinForwardingSecrets(),
       wamid,
       messageType: 'interactive',
-      message: interactive,
+      message: _redactFlowSensitiveFields(interactive),
       recipientPhone: userPhone,
       recipientBsuid: userBsuid,
       botPhoneNumberId,
@@ -146,4 +146,27 @@ export const startFlow = async ({ ctx, input, client, logger }: any) => {
 function _logForBotAndThrow(message: string, logger: any): never {
   logger.forBot().error(message)
   throw new RuntimeError(message)
+}
+
+/**
+ * The serialized Interactive carries `action.parameters.flow_token` (session/authorization
+ * token validated by the flow's data endpoint) and `flow_action_payload.data` (arbitrary
+ * initial screen data, potentially PII). Neither belongs in the Darwin envelope — Meta
+ * never echoes them either. Returns a redacted plain-object copy; on any failure returns
+ * a minimal marker object so forwarding stays best-effort.
+ */
+function _redactFlowSensitiveFields(interactive: Interactive): unknown {
+  try {
+    const plain = JSON.parse(JSON.stringify(interactive))
+    const parameters = plain?.action?.parameters
+    if (parameters && typeof parameters === 'object') {
+      delete parameters.flow_token
+      if (parameters.flow_action_payload && typeof parameters.flow_action_payload === 'object') {
+        delete parameters.flow_action_payload.data
+      }
+    }
+    return plain
+  } catch {
+    return { type: 'flow' }
+  }
 }

--- a/integrations/whatsapp/src/actions/start-flow.ts
+++ b/integrations/whatsapp/src/actions/start-flow.ts
@@ -1,6 +1,7 @@
 import { RuntimeError, z } from '@botpress/sdk'
 import { getDefaultBotPhoneNumberId, getAuthenticatedWhatsappClient } from '../auth'
 import { Interactive, Body, ActionFlow } from 'whatsapp-api-js/messages'
+import { forwardSentMessage } from '../misc/darwin-inbound-forwarding'
 import { buildConversationTags, chooseSendRecipient } from '../misc/identifier-decision'
 import * as bp from '.botpress'
 
@@ -111,6 +112,22 @@ export const startFlow = async ({ ctx, input, client, logger }: any) => {
       }" and action "${parameters.flow_action}" - Error: ${errorJSON}`,
       logger
     )
+  }
+
+  const wamid = 'messages' in response ? response.messages[0]?.id : undefined
+  if (wamid) {
+    // Best-effort forwarding to Darwin — never throws into the action path.
+    await forwardSentMessage({
+      url: bp.secrets.DARWIN_INBOUND_URL,
+      apiKey: bp.secrets.DARWIN_API_KEY,
+      wamid,
+      messageType: 'interactive',
+      message: interactive,
+      recipientPhone: userPhone,
+      recipientBsuid: userBsuid,
+      botPhoneNumberId,
+      logger,
+    })
   }
 
   logger

--- a/integrations/whatsapp/src/channels/channel.ts
+++ b/integrations/whatsapp/src/channels/channel.ts
@@ -15,6 +15,7 @@ import {
 } from 'whatsapp-api-js/messages'
 import { getAuthenticatedWhatsappClient } from '../auth'
 import { WHATSAPP } from '../misc/constants'
+import { forwardSentMessage } from '../misc/darwin-inbound-forwarding'
 import { chooseSendRecipient, MissingWhatsAppRecipientError, type SendRecipient } from '../misc/identifier-decision'
 import { convertMarkdownToWhatsApp } from '../misc/markdown-to-whatsapp-rtf'
 import { splitTextMessageIfNeeded } from '../misc/split-text-message'
@@ -342,7 +343,22 @@ async function _send({ client, ctx, conversation, logger, message, ack }: SendMe
   }
 
   logger.forBot().debug(`Successfully sent ${messageType} message from bot to WhatsApp:`, message)
-  await ack({ tags: { id: feedback.messages[0].id } })
+  const wamid = feedback.messages[0].id
+  await ack({ tags: { id: wamid } })
+
+  // Best-effort forwarding to Darwin, AFTER ack — never throws into the send path.
+  // Cloud API sends do not generate echo webhooks, so this is the only outbound signal.
+  await forwardSentMessage({
+    url: bp.secrets.DARWIN_INBOUND_URL,
+    apiKey: bp.secrets.DARWIN_API_KEY,
+    wamid,
+    messageType,
+    message,
+    recipientPhone: conversation.tags.userPhone,
+    recipientBsuid: conversation.tags.bsuid,
+    botPhoneNumberId,
+    logger,
+  })
 }
 
 async function _sendMany({

--- a/integrations/whatsapp/src/channels/channel.ts
+++ b/integrations/whatsapp/src/channels/channel.ts
@@ -16,6 +16,7 @@ import {
 import { getAuthenticatedWhatsappClient } from '../auth'
 import { WHATSAPP } from '../misc/constants'
 import { forwardSentMessage } from '../misc/darwin-inbound-forwarding'
+import { getDarwinForwardingSecrets } from '../misc/darwin-forwarding-secrets'
 import { chooseSendRecipient, MissingWhatsAppRecipientError, type SendRecipient } from '../misc/identifier-decision'
 import { convertMarkdownToWhatsApp } from '../misc/markdown-to-whatsapp-rtf'
 import { splitTextMessageIfNeeded } from '../misc/split-text-message'
@@ -349,8 +350,7 @@ async function _send({ client, ctx, conversation, logger, message, ack }: SendMe
   // Best-effort forwarding to Darwin, AFTER ack — never throws into the send path.
   // Cloud API sends do not generate echo webhooks, so this is the only outbound signal.
   await forwardSentMessage({
-    url: bp.secrets.DARWIN_INBOUND_URL,
-    apiKey: bp.secrets.DARWIN_API_KEY,
+    ...getDarwinForwardingSecrets(),
     wamid,
     messageType,
     message,

--- a/integrations/whatsapp/src/misc/darwin-forwarding-secrets.ts
+++ b/integrations/whatsapp/src/misc/darwin-forwarding-secrets.ts
@@ -1,0 +1,26 @@
+import * as bp from '.botpress'
+
+/**
+ * Safe accessor for the Darwin forwarding secrets. The generated `bp.secrets` getters
+ * THROW when the underlying env var is missing — reading them inline at a call site
+ * would crash the message send path in any environment where forwarding is simply not
+ * configured (sandbox, new workspace, secret rotation).
+ *
+ * Kept in its own module (instead of darwin-inbound-forwarding.ts) so the forwarding
+ * unit tests never pull `.botpress` at runtime.
+ */
+export function getDarwinForwardingSecrets(): { url: string | undefined; apiKey: string | undefined } {
+  let url: string | undefined
+  let apiKey: string | undefined
+  try {
+    url = bp.secrets.DARWIN_INBOUND_URL
+  } catch {
+    url = undefined
+  }
+  try {
+    apiKey = bp.secrets.DARWIN_API_KEY
+  } catch {
+    apiKey = undefined
+  }
+  return { url, apiKey }
+}

--- a/integrations/whatsapp/src/misc/darwin-inbound-forwarding.ts
+++ b/integrations/whatsapp/src/misc/darwin-inbound-forwarding.ts
@@ -9,7 +9,8 @@ type InboundContact = NonNullable<WhatsAppMessageValue['contacts']>[number]
 
 type BotMetadata = {
   phoneNumberId: string
-  displayPhoneNumber: string
+  // Optional in Darwin's DTO; unavailable at the send path (only webhook metadata carries it).
+  displayPhoneNumber?: string
 }
 
 type MessageEvent = {
@@ -164,6 +165,62 @@ export function buildOutboundEnvelope(
   }
 }
 
+export type SentMessageParams = {
+  wamid: string
+  /** Meta message type as exposed by whatsapp-api-js (`message._type`), e.g. 'text', 'image', 'template'. */
+  messageType: string
+  /** The whatsapp-api-js ClientMessage instance passed to `whatsapp.sendMessage`. */
+  message: unknown
+  recipientPhone: string | undefined
+  recipientBsuid: string | undefined
+  botPhoneNumberId: string
+  logger: bp.Logger
+}
+
+/**
+ * Pure builder: turns a just-sent Cloud API message into the Darwin contract envelope.
+ * whatsapp-api-js message classes JSON-serialize to the exact per-type sub-object the
+ * Meta API receives, matching the `content` shape of the inbound/echo builders.
+ * `sender` carries the RECIPIENT for outbound. Never throws.
+ */
+export function buildSentMessageEnvelope(params: SentMessageParams): DarwinEnvelope {
+  const { wamid, messageType, message, recipientPhone, recipientBsuid, botPhoneNumberId, logger } = params
+
+  let content: unknown = null
+  try {
+    content = JSON.parse(JSON.stringify(message))
+  } catch (thrown: unknown) {
+    const errMsg = thrown instanceof Error ? thrown.message : 'Unknown error thrown'
+    logger.forBot().error(`Failed to serialize sent ${messageType} message while forwarding to Darwin: ${errMsg}`)
+  }
+
+  const body = (content as Record<string, unknown> | null)?.body
+  const text = messageType === 'text' && typeof body === 'string' ? body : undefined
+
+  return {
+    source: 'whatsapp',
+    bot: {
+      phoneNumberId: botPhoneNumberId,
+    },
+    events: [
+      {
+        wamid,
+        occurredAt: new Date().toISOString(),
+        type: messageType,
+        direction: 'OUTBOUND',
+        content,
+        ...(text !== undefined && { text }),
+        sender: {
+          phone: recipientPhone ?? null,
+          bsuid: recipientBsuid ?? null,
+          name: null,
+        },
+        replyToWamid: null,
+      },
+    ],
+  }
+}
+
 /**
  * Pure builder: turns a single WhatsApp delivery status into the Darwin contract envelope.
  */
@@ -245,6 +302,37 @@ export async function forwardOutboundMessage(params: ForwardOutboundMessageParam
 
   const envelope = buildOutboundEnvelope(echo, value, logger)
   await postEnvelope(url, apiKey, envelope, logger, 'outbound WhatsApp message')
+}
+
+export type ForwardSentMessageParams = SentMessageParams & {
+  url: string | undefined
+  apiKey: string | undefined
+}
+
+/**
+ * Best-effort forwarder for messages just sent through the Cloud API. Same gating as the
+ * other forwarders. Cloud API sends never generate `smb_message_echoes` webhooks (echoes
+ * only cover WhatsApp Business App coexistence), so this is the only path that gets
+ * bot-sent messages to Darwin.
+ */
+export async function forwardSentMessage(params: ForwardSentMessageParams): Promise<void> {
+  const { url, apiKey, recipientPhone, recipientBsuid, logger } = params
+
+  if (!url || !apiKey) {
+    return
+  }
+
+  const gateKey = recipientPhone ?? recipientBsuid
+  if (!gateKey) {
+    return
+  }
+
+  if (!(await isInboundForwardingEnabled(gateKey, logger))) {
+    return
+  }
+
+  const envelope = buildSentMessageEnvelope(params)
+  await postEnvelope(url, apiKey, envelope, logger, 'sent WhatsApp message')
 }
 
 export type ForwardStatusParams = {

--- a/integrations/whatsapp/src/misc/darwin-inbound-forwarding.ts
+++ b/integrations/whatsapp/src/misc/darwin-inbound-forwarding.ts
@@ -47,6 +47,20 @@ export type InboundEnvelope = DarwinEnvelope
 const POST_TIMEOUT_MS = 3000
 
 /**
+ * Normalizes a phone identifier to the bare wa_id digits format used by the inbound
+ * webhook (e.g. '5511999999999'). The send path holds E.164 with a leading '+'
+ * (conversation tags / formatted input), while inbound/echo/status use Meta's wa_id —
+ * the Statsig gate rules and Darwin's contact matching must see ONE consistent format.
+ */
+function normalizePhone(phone: string | undefined): string | undefined {
+  if (!phone) {
+    return undefined
+  }
+  const normalized = phone.replace(/^\+/, '')
+  return normalized === '' ? undefined : normalized
+}
+
+/**
  * Converts a WhatsApp epoch-seconds timestamp string into an ISO-8601 UTC string.
  * Falls back to the current time (logged) when the timestamp is not a valid number,
  * so forwarding stays best-effort and never crashes the hot path.
@@ -211,7 +225,7 @@ export function buildSentMessageEnvelope(params: SentMessageParams): DarwinEnvel
         content,
         ...(text !== undefined && { text }),
         sender: {
-          phone: recipientPhone ?? null,
+          phone: normalizePhone(recipientPhone) ?? null,
           bsuid: recipientBsuid ?? null,
           name: null,
         },
@@ -314,25 +328,37 @@ export type ForwardSentMessageParams = SentMessageParams & {
  * other forwarders. Cloud API sends never generate `smb_message_echoes` webhooks (echoes
  * only cover WhatsApp Business App coexistence), so this is the only path that gets
  * bot-sent messages to Darwin.
+ *
+ * This runs inside the message SEND path (channel + proactive actions) — unlike the
+ * webhook forwarders there is no upstream try/catch protecting user-facing delivery,
+ * so the whole body is wrapped: it must never throw and never reject.
  */
 export async function forwardSentMessage(params: ForwardSentMessageParams): Promise<void> {
   const { url, apiKey, recipientPhone, recipientBsuid, logger } = params
 
-  if (!url || !apiKey) {
-    return
-  }
+  try {
+    if (!url || !apiKey) {
+      return
+    }
 
-  const gateKey = recipientPhone ?? recipientBsuid
-  if (!gateKey) {
-    return
-  }
+    // The gate rules are keyed by the bare wa_id format the inbound path has always
+    // used ('5511999999999'); the send path holds '+'-prefixed E.164 — normalize so
+    // the same user matches the same gate rule on both directions.
+    const gateKey = normalizePhone(recipientPhone) ?? recipientBsuid
+    if (!gateKey) {
+      return
+    }
 
-  if (!(await isInboundForwardingEnabled(gateKey, logger))) {
-    return
-  }
+    if (!(await isInboundForwardingEnabled(gateKey, logger))) {
+      return
+    }
 
-  const envelope = buildSentMessageEnvelope(params)
-  await postEnvelope(url, apiKey, envelope, logger, 'sent WhatsApp message')
+    const envelope = buildSentMessageEnvelope(params)
+    await postEnvelope(url, apiKey, envelope, logger, 'sent WhatsApp message')
+  } catch (thrown: unknown) {
+    const errMsg = thrown instanceof Error ? thrown.message : 'Unknown error thrown'
+    logger.forBot().error(`Failed to forward sent WhatsApp message to Darwin: ${errMsg}`)
+  }
 }
 
 export type ForwardStatusParams = {

--- a/integrations/whatsapp/src/misc/darwin-sent-message-forwarding.test.ts
+++ b/integrations/whatsapp/src/misc/darwin-sent-message-forwarding.test.ts
@@ -62,7 +62,9 @@ describe('buildSentMessageEnvelope', () => {
       text: 'hello world',
       replyToWamid: null,
     })
-    expect('content' in event && event.content).not.toHaveProperty('_type')
+    const content = 'content' in event ? event.content : undefined
+    expect(content).toBeDefined()
+    expect(content).not.toHaveProperty('_type')
   })
 
   test('emits a valid ISO-8601 occurredAt', () => {
@@ -73,6 +75,12 @@ describe('buildSentMessageEnvelope', () => {
 
   test('sender carries the recipient phone when only phone is available', () => {
     const envelope = buildSentMessageEnvelope(buildParams({ recipientPhone: PHONE, recipientBsuid: undefined }))
+    const event = envelope.events[0]!
+    expect('sender' in event && event.sender).toEqual({ phone: PHONE, bsuid: null, name: null })
+  })
+
+  test('normalizes E.164 phone to the bare wa_id format used by the inbound path', () => {
+    const envelope = buildSentMessageEnvelope(buildParams({ recipientPhone: `+${PHONE}`, recipientBsuid: undefined }))
     const event = envelope.events[0]!
     expect('sender' in event && event.sender).toEqual({ phone: PHONE, bsuid: null, name: null })
   })
@@ -183,6 +191,32 @@ describe('forwardSentMessage', () => {
       apiKey: API_KEY,
     })
     expect(isInboundForwardingEnabled).toHaveBeenCalledWith(PHONE, expect.anything())
+  })
+
+  test('consults the gate with the normalized wa_id format when the phone is E.164', async () => {
+    isInboundForwardingEnabled.mockResolvedValue(true)
+    await forwardSentMessage({
+      ...buildParams({ recipientPhone: `+${PHONE}`, recipientBsuid: undefined }),
+      url: URL,
+      apiKey: API_KEY,
+    })
+    expect(isInboundForwardingEnabled).toHaveBeenCalledWith(PHONE, expect.anything())
+  })
+
+  test('never rejects when the gate check itself throws (send path never breaks)', async () => {
+    const { logger, error } = buildLogger()
+    isInboundForwardingEnabled.mockRejectedValue(new Error('statsig exploded'))
+
+    await expect(
+      forwardSentMessage({
+        ...buildParams({ logger: logger as never }),
+        url: URL,
+        apiKey: API_KEY,
+      })
+    ).resolves.toBeUndefined()
+
+    expect(mockedAxiosPost).not.toHaveBeenCalled()
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('statsig exploded'))
   })
 
   test('consults the gate with the bsuid when phone is missing', async () => {

--- a/integrations/whatsapp/src/misc/darwin-sent-message-forwarding.test.ts
+++ b/integrations/whatsapp/src/misc/darwin-sent-message-forwarding.test.ts
@@ -1,0 +1,240 @@
+import axios from 'axios'
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+import { Image, Template, Language, Text } from 'whatsapp-api-js/messages'
+import { RawInteractiveMessage } from '../channels/message-types/raw-interactive'
+import { buildSentMessageEnvelope, forwardSentMessage, SentMessageParams } from './darwin-inbound-forwarding'
+
+vi.mock('axios', () => ({
+  default: {
+    post: vi.fn(),
+  },
+}))
+
+const isInboundForwardingEnabled = vi.fn()
+vi.mock('./feature-toggle', () => ({
+  isInboundForwardingEnabled: (...args: unknown[]) => isInboundForwardingEnabled(...args),
+}))
+
+const mockedAxiosPost = vi.mocked(axios.post)
+
+const URL = 'https://darwin.example.com/inbound'
+const API_KEY = 'secret-api-key'
+const PHONE = '5511999999999'
+const BSUID = 'BR.1234567890'
+const WAMID = 'wamid.SENT'
+const BOT_PHONE_NUMBER_ID = 'phone-number-id-1'
+
+function buildLogger() {
+  const error = vi.fn()
+  const logger = { forBot: () => ({ error }) }
+  return { logger, error }
+}
+
+function buildParams(overrides: Partial<SentMessageParams> = {}): SentMessageParams {
+  const { logger } = buildLogger()
+  return {
+    wamid: WAMID,
+    messageType: 'text',
+    message: new Text('hello world'),
+    recipientPhone: PHONE,
+    recipientBsuid: undefined,
+    botPhoneNumberId: BOT_PHONE_NUMBER_ID,
+    logger: logger as never,
+    ...overrides,
+  }
+}
+
+describe('buildSentMessageEnvelope', () => {
+  test('builds an OUTBOUND text event with content matching the Meta per-type sub-object', () => {
+    const envelope = buildSentMessageEnvelope(buildParams())
+
+    expect(envelope.source).toBe('whatsapp')
+    expect(envelope.bot).toEqual({ phoneNumberId: BOT_PHONE_NUMBER_ID })
+    expect(envelope.bot).not.toHaveProperty('displayPhoneNumber')
+    expect(envelope.events).toHaveLength(1)
+
+    const event = envelope.events[0]!
+    expect(event).toMatchObject({
+      wamid: WAMID,
+      type: 'text',
+      direction: 'OUTBOUND',
+      content: { body: 'hello world' },
+      text: 'hello world',
+      replyToWamid: null,
+    })
+    expect('content' in event && event.content).not.toHaveProperty('_type')
+  })
+
+  test('emits a valid ISO-8601 occurredAt', () => {
+    const envelope = buildSentMessageEnvelope(buildParams())
+    const event = envelope.events[0]!
+    expect('occurredAt' in event && Number.isFinite(Date.parse(event.occurredAt))).toBe(true)
+  })
+
+  test('sender carries the recipient phone when only phone is available', () => {
+    const envelope = buildSentMessageEnvelope(buildParams({ recipientPhone: PHONE, recipientBsuid: undefined }))
+    const event = envelope.events[0]!
+    expect('sender' in event && event.sender).toEqual({ phone: PHONE, bsuid: null, name: null })
+  })
+
+  test('sender carries the recipient bsuid when only bsuid is available', () => {
+    const envelope = buildSentMessageEnvelope(buildParams({ recipientPhone: undefined, recipientBsuid: BSUID }))
+    const event = envelope.events[0]!
+    expect('sender' in event && event.sender).toEqual({ phone: null, bsuid: BSUID, name: null })
+  })
+
+  test('sender carries both identifiers when both are available', () => {
+    const envelope = buildSentMessageEnvelope(buildParams({ recipientPhone: PHONE, recipientBsuid: BSUID }))
+    const event = envelope.events[0]!
+    expect('sender' in event && event.sender).toEqual({ phone: PHONE, bsuid: BSUID, name: null })
+  })
+
+  test('builds a media event without a text key', () => {
+    const envelope = buildSentMessageEnvelope(
+      buildParams({ messageType: 'image', message: new Image('https://cdn.example.com/a.jpg', false, 'caption') })
+    )
+    const event = envelope.events[0]!
+    expect(event).toMatchObject({
+      type: 'image',
+      direction: 'OUTBOUND',
+      content: { link: 'https://cdn.example.com/a.jpg', caption: 'caption' },
+    })
+    expect(event).not.toHaveProperty('text')
+  })
+
+  test('serializes a Template instance to the Meta template payload', () => {
+    const envelope = buildSentMessageEnvelope(
+      buildParams({ messageType: 'template', message: new Template('my_template', new Language('pt_BR')) })
+    )
+    const event = envelope.events[0]!
+    expect(event).toMatchObject({
+      type: 'template',
+      content: { name: 'my_template', language: { code: 'pt_BR' } },
+    })
+    expect(event).not.toHaveProperty('text')
+  })
+
+  test('honors toJSON overrides (RawInteractiveMessage serializes to its raw payload)', () => {
+    const payload = {
+      type: 'cta_url' as const,
+      body: { text: 'click here' },
+      action: { name: 'cta_url' as const, parameters: { display_text: 'Open', url: 'https://example.com' } },
+    }
+    const envelope = buildSentMessageEnvelope(
+      buildParams({ messageType: 'interactive', message: new RawInteractiveMessage(payload) })
+    )
+    const event = envelope.events[0]!
+    expect('content' in event && event.content).toEqual(payload)
+  })
+
+  test('never throws: unserializable message yields null content and logs the error', () => {
+    const { logger, error } = buildLogger()
+    const cyclic: Record<string, unknown> = {}
+    cyclic['self'] = cyclic
+
+    const envelope = buildSentMessageEnvelope(buildParams({ message: cyclic, logger: logger as never }))
+
+    const event = envelope.events[0]!
+    expect('content' in event && event.content).toBeNull()
+    expect(event).not.toHaveProperty('text')
+    expect(error).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('forwardSentMessage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('skips without consulting the gate when url is missing', async () => {
+    await forwardSentMessage({ ...buildParams(), url: undefined, apiKey: API_KEY })
+    expect(isInboundForwardingEnabled).not.toHaveBeenCalled()
+    expect(mockedAxiosPost).not.toHaveBeenCalled()
+  })
+
+  test('skips without consulting the gate when apiKey is missing', async () => {
+    await forwardSentMessage({ ...buildParams(), url: URL, apiKey: undefined })
+    expect(isInboundForwardingEnabled).not.toHaveBeenCalled()
+    expect(mockedAxiosPost).not.toHaveBeenCalled()
+  })
+
+  test('skips silently when neither recipient identifier is available', async () => {
+    await forwardSentMessage({
+      ...buildParams({ recipientPhone: undefined, recipientBsuid: undefined }),
+      url: URL,
+      apiKey: API_KEY,
+    })
+    expect(isInboundForwardingEnabled).not.toHaveBeenCalled()
+    expect(mockedAxiosPost).not.toHaveBeenCalled()
+  })
+
+  test('skips when the gate is off', async () => {
+    isInboundForwardingEnabled.mockResolvedValue(false)
+    await forwardSentMessage({ ...buildParams(), url: URL, apiKey: API_KEY })
+    expect(isInboundForwardingEnabled).toHaveBeenCalledWith(PHONE, expect.anything())
+    expect(mockedAxiosPost).not.toHaveBeenCalled()
+  })
+
+  test('consults the gate with the phone when both identifiers are available', async () => {
+    isInboundForwardingEnabled.mockResolvedValue(true)
+    await forwardSentMessage({
+      ...buildParams({ recipientPhone: PHONE, recipientBsuid: BSUID }),
+      url: URL,
+      apiKey: API_KEY,
+    })
+    expect(isInboundForwardingEnabled).toHaveBeenCalledWith(PHONE, expect.anything())
+  })
+
+  test('consults the gate with the bsuid when phone is missing', async () => {
+    isInboundForwardingEnabled.mockResolvedValue(true)
+    await forwardSentMessage({
+      ...buildParams({ recipientPhone: undefined, recipientBsuid: BSUID }),
+      url: URL,
+      apiKey: API_KEY,
+    })
+    expect(isInboundForwardingEnabled).toHaveBeenCalledWith(BSUID, expect.anything())
+  })
+
+  test('posts the built envelope with the X-API-KEY header when the gate is on', async () => {
+    isInboundForwardingEnabled.mockResolvedValue(true)
+    mockedAxiosPost.mockResolvedValue({ status: 200 })
+
+    await forwardSentMessage({ ...buildParams(), url: URL, apiKey: API_KEY })
+
+    expect(mockedAxiosPost).toHaveBeenCalledTimes(1)
+    const [calledUrl, envelope, config] = mockedAxiosPost.mock.calls[0]!
+    expect(calledUrl).toBe(URL)
+    expect(envelope).toMatchObject({
+      source: 'whatsapp',
+      bot: { phoneNumberId: BOT_PHONE_NUMBER_ID },
+      events: [
+        {
+          wamid: WAMID,
+          type: 'text',
+          direction: 'OUTBOUND',
+          content: { body: 'hello world' },
+          text: 'hello world',
+          sender: { phone: PHONE, bsuid: null, name: null },
+          replyToWamid: null,
+        },
+      ],
+    })
+    expect(config?.headers).toMatchObject({ 'X-API-KEY': API_KEY })
+  })
+
+  test('swallows axios failures and logs them (send path never breaks)', async () => {
+    const { logger, error } = buildLogger()
+    isInboundForwardingEnabled.mockResolvedValue(true)
+    mockedAxiosPost.mockRejectedValue(new Error('connection refused'))
+
+    await expect(
+      forwardSentMessage({
+        ...buildParams({ logger: logger as never }),
+        url: URL,
+        apiKey: API_KEY,
+      })
+    ).resolves.toBeUndefined()
+
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('connection refused'))
+  })
+})

--- a/integrations/whatsapp/src/misc/statsig.ts
+++ b/integrations/whatsapp/src/misc/statsig.ts
@@ -3,15 +3,20 @@ import * as bp from '.botpress'
 
 let initialized = false
 
-export async function isGateEnabled(gateName: string, userID: string, logger: bp.Logger): Promise<boolean> {
-  const apiKey = bp.secrets.STATSIG_API_KEY
-  if (!apiKey) {
-    return false
-  }
+// The gate check now also runs in the message send path, so a slow/unreachable Statsig
+// must never hang a send indefinitely (the SDK default is no timeout at all).
+const INIT_TIMEOUT_MS = 2000
 
+export async function isGateEnabled(gateName: string, userID: string, logger: bp.Logger): Promise<boolean> {
   try {
+    // Inside the try: the generated secret getter THROWS when the env var is missing.
+    const apiKey = bp.secrets.STATSIG_API_KEY
+    if (!apiKey) {
+      return false
+    }
+
     if (!initialized) {
-      await statsig.initialize(apiKey)
+      await statsig.initialize(apiKey, { initTimeoutMs: INIT_TIMEOUT_MS })
       initialized = true
     }
     return statsig.checkGateSync({ userID }, gateName)


### PR DESCRIPTION
## Summary

v1.5.0 forwarded outbound messages to Darwin only via the `smb_message_echoes` webhook. Meta only sends that webhook for messages sent from the **WhatsApp Business App** (coexistence) — messages sent by the bot via **Cloud API never generate echoes**. Verified in New Relic: zero OUTBOUND envelopes reached Darwin in 7 days, while inbound (200) and status events flowed normally.

This adds a best-effort forward right after Meta returns the wamid, covering all three send paths:

- `channel.ts` `_send()` — covers text, image, audio, video, file, location, bloc, carousel/card/dropdown/choice; forward runs AFTER `ack`.
- `startConversation` action — forwards the sent template when a wamid is returned.
- `startFlow` action — now also extracts the wamid from the send response (didn't before) and forwards the Flow interactive.

## Design

- New `buildSentMessageEnvelope`/`forwardSentMessage` in `darwin-inbound-forwarding.ts`, reusing the existing gating (secrets + Statsig gate `botpress-whatsapp-events-forwarding`, fail-closed) and `postEnvelope` (3s timeout, errors swallowed — never breaks the send path).
- whatsapp-api-js message instances JSON-serialize to the exact per-type sub-object Meta receives, so `content` matches the inbound/echo envelope shape.
- `BotMetadata.displayPhoneNumber` becomes optional — unavailable at send time; already optional in Darwin's DTO.
- Echo handler unchanged: still covers app-sent messages in coexistence; Darwin dedupes by wamid.
- Bumps integration version to **1.5.1**; tag `whatsapp-stay-1.5.1` pushed.

## Tests

- New `darwin-sent-message-forwarding.test.ts`: 17 tests (builder shape per message type incl. RawInteractiveMessage toJSON, never-throws on unserializable content, gating variants, POST headers/envelope, axios failure swallowed).
- 123 tests passing overall; `bp build` and `bp deploy --dryRun` green (all secrets unchanged).

## Deploy

Not deployed yet — publishing v1.5.1 + bot upgrade will be done manually. End-to-end also requires the Darwin-side validation fix (global pipe `enableImplicitConversion` corrupting status events), prepared separately in the darwin repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)