### PR TITLE
docs(whatsapp-stay): CLAUDE.md da integração + doc de customizações + skill de deploy

### DIFF
--- a/.claude/skills/whatsapp-stay-deploy/SKILL.md
+++ b/.claude/skills/whatsapp-stay-deploy/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: whatsapp-stay-deploy
+description: >
+  Guia o deploy da integração privada whatsapp-stay (@stay/whatsapp-stay) no
+  workspace do Botpress: bump de versão, checks, build, dry-run e deploy real,
+  com um gate obrigatório de permissão explícita do dev antes do publish. Use
+  quando: deploy whatsapp, publicar whatsapp-stay, subir versão da integração
+  whatsapp, deploy da integração whatsapp, bp deploy whatsapp.
+---
+
+# whatsapp-stay-deploy
+
+Runbook executável para publicar uma nova versão de `integrations/whatsapp`
+(`@stay/whatsapp-stay`). O detalhe canônico (login, PAT, workspace ID, secrets,
+upgrade dos bots, rollback) está em [`../../../integrations/whatsapp/README.md`](../../../integrations/whatsapp/README.md).
+
+## 🚨 Gate inegociável
+
+**NUNCA rode `bp deploy` sem `--dryRun` sem autorização EXPLÍCITA do dev, para cada deploy.**
+Publish é irreversível (não há *unpublish*) e afeta o workspace inteiro.
+Autorização de um deploy anterior NÃO vale para o próximo. Na dúvida, PARE e pergunte.
+
+## Passos
+
+Todos os comandos rodam a partir de `integrations/whatsapp`.
+
+1. **Confirme o alvo.** `bp profiles active` — o workspace precisa ser o correto
+   (sandbox vs produção). Deploy no workspace errado é o erro mais comum. Se estiver
+   errado, `bp profiles use <perfil>` antes de continuar.
+2. **Bump de versão** em `integration.definition.ts` (`INTEGRATION_VERSION`), SemVer:
+   patch = bugfix, minor = feature retrocompatível, major = breaking no contrato.
+   Deploy com versão já publicada falha no servidor.
+3. **Checks verdes** (não prossiga com qualquer um vermelho):
+   ```bash
+   pnpm run check:type
+   pnpm run check:bplint
+   pnpm run test
+   pnpm run build
+   ```
+4. **Dry run** (valida sem publicar — precisa passar):
+   ```bash
+   bp deploy --dryRun --visibility private -y \
+     --secrets POSTHOG_KEY=disabled \
+     --secrets SANDBOX_CLIENT_SECRET=placeholder \
+     --secrets SANDBOX_VERIFY_TOKEN=placeholder \
+     --secrets SANDBOX_ACCESS_TOKEN=placeholder \
+     --secrets SANDBOX_PHONE_NUMBER_ID=placeholder \
+     --secrets STATSIG_API_KEY=placeholder \
+     --secrets DARWIN_INBOUND_URL=placeholder \
+     --secrets DARWIN_API_KEY=placeholder
+   ```
+   Se reclamar de secret faltando, adicione ao comando (a lista canônica é o bloco
+   `secrets` de `integration.definition.ts`). Se reclamar de versão existente, volte ao passo 2.
+5. **⛔ PARE. Peça autorização explícita ao dev para o deploy real.** Só continue com um "sim" claro.
+6. **Deploy real** — mesmo comando sem `--dryRun`, com os valores **reais** dos secrets
+   (cofre/1Password). Proteja o shell history (`set +o history` ou secrets via env).
+7. **Pós-deploy:** avise os donos dos bots — o upgrade da versão em cada bot é **manual**
+   (Studio ou bot-as-code). Ver README → "Pós-deploy: upgrade nos bots".
+
+## Rollback
+
+Não há unpublish. Reverta fazendo downgrade da referência da integração em cada bot
+e publicando um patch com o fix. Detalhe no README → "Rollback".

--- a/integrations/whatsapp/CLAUDE.md
+++ b/integrations/whatsapp/CLAUDE.md
@@ -1,0 +1,73 @@
+# CLAUDE.md — Integração `whatsapp-stay`
+
+Fork **privado** da integração oficial `whatsapp` do Botpress, mantido pela Stay
+(`@stay/whatsapp-stay`). Mantém todo o comportamento original e adiciona capacidades
+de produto (WhatsApp Flows, BSUID) e integração com o **Darwin** (forwarding de eventos).
+
+Este arquivo é um **índice**. O detalhe vive nos docs/arquivos linkados — abra o que for relevant à sua tarefa.
+
+## 🚨 Regra de ouro: NUNCA faça deploy sem permissão explícita do dev
+
+Publicar uma versão é irreversível (não há *unpublish*) e afeta o workspace inteiro.
+Você pode editar, buildar, rodar checks e até `--dryRun`. **Deploy real (`bp deploy` sem `--dryRun`)
+exige autorização explícita do dev, para cada deploy.** Autorização anterior não vale para o próximo.
+
+## O que este fork adiciona (mapa)
+
+| Capability | Onde | Detalhe |
+|---|---|---|
+| Action `startFlow` (WhatsApp Flows) | [`src/actions/start-flow.ts`](src/actions/start-flow.ts) | [README §1](README.md#1-action-startflow--envio-de-whatsapp-flows) |
+| Identidade por **BSUID** | [`src/misc/bsuid-extraction.ts`](src/misc/bsuid-extraction.ts), [`identifier-decision.ts`](src/misc/identifier-decision.ts) | [README §2](README.md#2-suporte-a-bsuid-business-scoped-user-id) |
+| Forwarding p/ **Darwin** (inbound/outbound/status) | [`src/misc/darwin-inbound-forwarding.ts`](src/misc/darwin-inbound-forwarding.ts) | [docs/stay-customizations.md](docs/stay-customizations.md#forwarding-para-o-darwin) |
+| Feature toggle via **Statsig** | [`src/misc/feature-toggle.ts`](src/misc/feature-toggle.ts), [`statsig.ts`](src/misc/statsig.ts) | [docs/stay-customizations.md](docs/stay-customizations.md#feature-toggle-statsig) |
+
+Arquitetura das customizações Stay: **[docs/stay-customizations.md](docs/stay-customizations.md)**.
+Tudo que não estiver listado aqui vem do upstream `botpress/botpress` — evite divergir sem motivo.
+
+## Estrutura
+
+- `src/actions/` — actions expostas ao bot (inclui `start-flow.ts`).
+- `src/channels/` — renderização de mensagens de saída por tipo.
+- `src/webhook/handlers/` — entrada dos eventos do Meta (`messages`, `echo`, `status`, `oauth`, `sandbox`). **Pontos onde o forwarding p/ Darwin está plugado.**
+- `src/misc/` — utilidades + módulos Stay (BSUID, Darwin, Statsig).
+- `integration.definition.ts` — nome, versão, config, **secrets** e schemas. Fonte da verdade do contrato.
+
+## Como fazer alterações
+
+1. Descubra o arquivo pelo mapa acima. Se mexe em forwarding/toggle/identidade, **leia [docs/stay-customizations.md](docs/stay-customizations.md) antes** — há invariantes (best-effort, fail-safe) que precisam ser preservados.
+2. Escreva o código seguindo o estilo do entorno. Custom sempre com **teste** (`*.test.ts` ao lado — vitest).
+3. Rode localmente, do diretório da integração:
+   ```bash
+   cd integrations/whatsapp
+   pnpm run test          # vitest
+   pnpm run check:type    # tsc --noEmit
+   pnpm run check:bplint  # bp lint
+   pnpm run build         # bp add -y && bp build
+   ```
+4. Secret novo? Declare em `integration.definition.ts` (bloco `secrets`) e documente no README + no comando de deploy.
+5. Regras de teste (do CLAUDE global): **adicionar** testes/asserções é livre; **modificar/remover** setup ou asserções existentes exige autorização do dev.
+
+### Convenções
+
+- Não quebrar o contrato do upstream sem necessidade; mudança de contrato (action/event/config) = bump **major**.
+- Toda customização Stay fica isolada em módulo próprio em `src/misc/` e é plugada nos handlers — não espalhe lógica Stay dentro do código herdado.
+- Forwarding é **best-effort**: nunca lançar para o hot path do bot.
+
+## Como fazer o deploy
+
+Runbook completo (pré-requisitos, login, bump, dry-run, deploy, upgrade dos bots, rollback):
+**[README.md → "Deploy de uma nova versão"](README.md#deploy-de-uma-nova-versão)**.
+
+Fluxo guiado e com o *gate* de permissão embutido: skill **[`whatsapp-stay-deploy`](../../.claude/skills/whatsapp-stay-deploy/SKILL.md)**.
+
+Resumo (o detalhe está no README — não pule etapas):
+
+1. Bump da versão em `integration.definition.ts` (SemVer).
+2. `check:type` + `check:bplint` + `test` verdes → `pnpm run build`.
+3. `bp profiles active` → confirme o **workspace correto**.
+4. `bp deploy --dryRun --visibility private -y --secrets ...` → precisa passar.
+5. **PARE e peça autorização explícita ao dev.**
+6. Só então `bp deploy --visibility private -y --secrets <reais>`.
+7. Avise os donos dos bots (upgrade não é automático).
+
+> Deploy publica no **workspace**, não nos bots. Cada bot faz upgrade manual da versão.

--- a/integrations/whatsapp/docs/stay-customizations.md
+++ b/integrations/whatsapp/docs/stay-customizations.md
@@ -1,0 +1,55 @@
+# Customizações Stay — `whatsapp-stay`
+
+Detalhamento do que o fork adiciona sobre a integração oficial `whatsapp` do Botpress.
+Doc de referência do [CLAUDE.md](../CLAUDE.md) — features de produto (Flows, BSUID) e passo a passo de deploy vivem no [README.md](../README.md).
+
+## Mapa dos módulos custom
+
+| Capability | Código | Ticket |
+|---|---|---|
+| WhatsApp Flows (`startFlow`) | [`src/actions/start-flow.ts`](../src/actions/start-flow.ts) | FOU-* |
+| Identidade por BSUID | [`src/misc/bsuid-extraction.ts`](../src/misc/bsuid-extraction.ts), [`src/misc/identifier-decision.ts`](../src/misc/identifier-decision.ts) | FOU-320/328/339 |
+| Forwarding p/ Darwin | [`src/misc/darwin-inbound-forwarding.ts`](../src/misc/darwin-inbound-forwarding.ts) | FOU-541/530 |
+| Feature toggle (Statsig) | [`src/misc/feature-toggle.ts`](../src/misc/feature-toggle.ts), [`src/misc/statsig.ts`](../src/misc/statsig.ts) | FOU-550 |
+
+## Forwarding para o Darwin
+
+O fork encaminha eventos de WhatsApp para o Darwin, em três pontos do webhook:
+
+- **Inbound** (mensagem do usuário) — `forwardInboundMessage`, chamado em [`src/webhook/handlers/messages.ts`](../src/webhook/handlers/messages.ts).
+- **Outbound** (echo da mensagem enviada pelo bot/atendente) — `forwardOutboundMessage`, chamado em [`src/webhook/handlers/echo.ts`](../src/webhook/handlers/echo.ts).
+- **Status** (sent/delivered/read/failed) — `forwardStatus`, chamado em [`src/webhook/handlers/status.ts`](../src/webhook/handlers/status.ts).
+
+Contrato: `DarwinEnvelope` (`{ source: 'whatsapp', bot, events[] }`), montado por builders puros (`buildInboundEnvelope`, `buildOutboundEnvelope`, `buildStatusEnvelope`).
+
+Regras invioláveis do encaminhamento (ao mexer, **preserve**):
+
+- **Best-effort e fora do hot path.** O POST roda *depois* do processamento do bot e qualquer erro é logado e engolido — nunca lança para o fluxo principal (ver `postEnvelope`). Não transforme forwarding em caminho crítico.
+- **Timeout curto** (`POST_TIMEOUT_MS = 3000`). Autenticação via header `X-API-KEY`.
+- **Mídia não é baixada** — `content` é o sub-objeto cru por tipo, exatamente como veio do Meta.
+- **Timestamp** convertido para ISO-8601 UTC (`toIsoOccurredAt`), com fallback para "agora" logado quando inválido.
+
+Secrets usados: `DARWIN_INBOUND_URL`, `DARWIN_API_KEY` (ver bloco `secrets` em [`integration.definition.ts`](../integration.definition.ts)).
+
+## Feature toggle (Statsig)
+
+O inbound forwarding é *gated* pela flag Statsig `botpress-whatsapp-events-forwarding`
+(constante `INBOUND_FORWARDING_GATE` em [`feature-toggle.ts`](../src/misc/feature-toggle.ts)).
+
+- `isGateEnabled(gate, userID, logger)` em [`statsig.ts`](../src/misc/statsig.ts) inicializa o SDK sob demanda.
+- Sem `STATSIG_API_KEY` a gate **retorna `false`** (fail-safe: não encaminha).
+- O `userID` avaliado é o telefone do usuário.
+
+## Identidade: telefone x BSUID
+
+A oficial só endereça por número. O fork adiciona o **BSUID** (Business-Scoped User ID, `{ISO 3166}.{alfanumérico}`):
+
+- `extractContactIdentifiers` ([`bsuid-extraction.ts`](../src/misc/bsuid-extraction.ts)) tira `{ bsuid, phone }` de contatos/status do webhook.
+- `chooseSendRecipient` / `buildConversationTags` ([`identifier-decision.ts`](../src/misc/identifier-decision.ts)) decidem o destinatário ao enviar: usa `userPhone` se houver, senão `bsuid`. Sem nenhum dos dois → `MissingWhatsAppRecipientError`.
+- `bsuid` é persistido como tag de `user` e de `conversation`.
+
+Contexto de produto em [README.md](../README.md#2-suporte-a-bsuid-business-scoped-user-id).
+
+## WhatsApp Flows (`startFlow`)
+
+Action de primeira classe para disparar Flows nativos do WhatsApp. Contrato de input/output documentado no [README.md](../README.md#1-action-startflow--envio-de-whatsapp-flows). Código em [`start-flow.ts`](../src/actions/start-flow.ts); reusa `chooseSendRecipient` para resolver telefone/BSUID.


### PR DESCRIPTION
## O que

Documentação direcionada à integração **`whatsapp-stay`** (fork privado da integração oficial do Botpress), com **progressive disclosure**:

- **`integrations/whatsapp/CLAUDE.md`** (73 linhas) — índice enxuto: regra de ouro (nunca deploy sem permissão), mapa das customizações, estrutura, como alterar/testar e resumo do deploy. Aponta para os docs de detalhe em vez de despejar tudo inline.
- **`integrations/whatsapp/docs/stay-customizations.md`** — arquitetura das customizações Stay: forwarding p/ Darwin (inbound/outbound/status + invariantes best-effort), feature toggle Statsig, identidade BSUID e action `startFlow`, com links pro código.
- **`.claude/skills/whatsapp-stay-deploy/SKILL.md`** — skill que guia o deploy passo a passo com **gate obrigatório de permissão explícita do dev** antes do publish.

O `README.md` existente (features + runbook completo de deploy) segue como fonte canônica; o CLAUDE.md apenas indexa e linka.

## Notas

- `CLAUDE.md` e `.claude` são gitignorados; adicionados com `git add -f`, seguindo o precedente dos CLAUDE.md já versionados (`packages/llmz`, `packages/zai`).
- Sem mudança de código de runtime — apenas documentação e skill.

## Revisão

Aguardando revisão do dev. **Nada de merge nem deploy** sem aprovação.

🤖 Generated with [Claude Code](https://claude.com/claude-code)